### PR TITLE
Add script to build, run and collect benchmark results

### DIFF
--- a/scripts/autohecbench-compare.py
+++ b/scripts/autohecbench-compare.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Script to compare to result files
+
+import argparse
+import csv
+import statistics
+
+def main():
+    parser = argparse.ArgumentParser(description='Benchmarks comparisons')
+
+    parser.add_argument('input', nargs=2,
+                        help='Two benchmark result files to compute speedup between (OLD NEW)')
+
+    args = parser.parse_args()
+
+    data = dict()
+    for res in args.input:
+        with open(res, 'r') as f:
+            c = csv.reader(f, delimiter=',')
+            data[res] = { r[0].split('-')[0]: list(map(float, r[1:])) for r in c }
+
+    a = data[args.input[0]]
+    b = data[args.input[1]]
+
+    speedups = []
+    print("|Benchmark|Speedup")
+    print("|--|--")
+    for k, v in a.items():
+        if not k in b:
+            continue
+
+        ma = sum(a[k]) / len(a[k])
+        mb = sum(b[k]) / len(b[k])
+
+        speedup = ma / mb
+        speedups.append(speedup)
+
+        print("|{}|{:.2f}".format(k, ma / mb))
+    print("|--|--")
+    print("|Geomean|{}".format(statistics.geometric_mean(speedups)))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/autohecbench.py
+++ b/scripts/autohecbench.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+#
+# Script to run HeCBench benchmarks and gather results
+
+import re, time, sys, subprocess, multiprocessing, os
+import argparse
+import json
+
+class Benchmark:
+    def __init__(self, args, name, res_regex, run_args = [], binary = "main", invert = False):
+        if name.endswith('sycl'):
+            self.MAKE_ARGS = ['GCC_TOOLCHAIN="{}"'.format(args.gcc_toolchain)]
+            if args.sycl_type == 'cuda':
+                self.MAKE_ARGS.append('CUDA=yes')
+                self.MAKE_ARGS.append('CUDA_ARCH=sm_{}'.format(args.nvidia_sm))
+            elif args.sycl_type == 'hip':
+                self.MAKE_ARGS.append('HIP=yes')
+                self.MAKE_ARGS.append('HIP_ARCH={}'.format(args.amd_arch))
+        else:
+            self.MAKE_ARGS = []
+
+        if args.bench_dir:
+            self.path = os.path.realpath(os.path.join(args.bench_dir, name))
+        else:
+            self.path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', name)
+
+        self.name = name
+        self.binary = binary
+        self.res_regex = res_regex
+        self.args = run_args
+        self.invert = invert
+        self.clean = args.clean
+        self.verbose = args.verbose
+
+    def compile(self):
+        if self.clean:
+            subprocess.run(["make", "clean"], cwd=self.path).check_returncode()
+            time.sleep(1) # required to make sure clean is done before building, despite run waiting on the invoked executable
+
+        out = subprocess.DEVNULL
+        if self.verbose:
+            out = None
+
+        subprocess.run(["make"] + self.MAKE_ARGS, cwd=self.path, stdout=out, stderr=out).check_returncode()
+
+    def run(self):
+        cmd = ["./" + self.binary] + self.args
+        proc = subprocess.run(cmd, cwd=self.path, stdout=subprocess.PIPE, encoding="ascii")
+        out = proc.stdout
+        if self.verbose:
+            print(" ".join(cmd))
+            print(out)
+        res = re.findall(self.res_regex, out)
+        if not res:
+            raise Exception(self.path + ":\nno regex match for " + self.res_regex + " in\n" + out)
+        res = sum([float(i) for i in res]) #in case of multiple outputs sum them
+        if self.invert:
+            res = 1/res
+        return res
+
+
+def comp(b):
+    print("compiling: {}".format(b.name))
+    b.compile()
+
+def main():
+    parser = argparse.ArgumentParser(description='HeCBench runner')
+    parser.add_argument('--output', '-o',
+                        help='Output file for csv results')
+    parser.add_argument('--repeat', '-r', type=int, default=1,
+                        help='Repeat benchmark run')
+    parser.add_argument('--warmup', '-w', type=bool, default=True,
+                        help='Run a warmup iteration')
+    parser.add_argument('--sycl-type', '-s', choices=['cuda', 'hip'], default='cuda',
+                        help='Type of SYCL device to use')
+    parser.add_argument('--nvidia-sm', type=int, default=60,
+                        help='NVIDIA SM version')
+    parser.add_argument('--amd-arch', default='gfx908',
+                        help='AMD Architecture')
+    parser.add_argument('--gcc-toolchain', default='',
+                        help='GCC toolchain location')
+    parser.add_argument('--clean', '-c', action='store_true',
+                        help='Clean the builds')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Clean the builds')
+    parser.add_argument('--bench-dir', '-b',
+                        help='Benchmark directory')
+    parser.add_argument('--bench-data', '-d',
+                        help='Benchmark data')
+    parser.add_argument('--bench-fails', '-f',
+                        help='List of failing benchmarks to ignore')
+    parser.add_argument('bench', nargs='+',
+                        help='Either specific benchmark name or sycl, cuda, or hip')
+
+    args = parser.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Load benchmark data
+    if args.bench_data:
+        bench_data = args.bench_data
+    else:
+        bench_data = os.path.join(script_dir, 'benchmarks', 'subset.json') 
+
+    with open(bench_data) as f:
+        benchmarks = json.load(f)
+
+    # Load fail file
+    if args.bench_fails:
+        bench_fails = os.path.abspath(args.bench_fails)
+    else:
+        bench_fails = os.path.join(script_dir, 'benchmarks', 'subset-fails.txt')
+
+    with open(bench_fails) as f:
+        fails = f.read().splitlines()
+
+    # Build benchmark list
+    benches = []
+    for b in args.bench:
+        if b in ['sycl', 'cuda', 'hip']:
+            benches.extend([Benchmark(args, k, *v)
+                            for k, v in benchmarks.items()
+                            if k.endswith(b) and k not in fails])
+            continue
+
+        benches.append(Benchmark(args, b, *benchmarks[b]))
+
+    t0 = time.time()
+    with multiprocessing.Pool() as p:
+        p.map(comp, benches)
+
+    t_compiled = time.time()
+
+    outfile = sys.stdout
+    if args.output:
+        outfile = open(args.output, 'w')
+
+    for b in benches:
+        if args.verbose:
+            print("running: {}".format(b.name))
+
+        if args.warmup:
+            b.run()
+
+        res = []
+        for i in range(args.repeat):
+            res.append(str(b.run()))
+
+        print(b.name + "," + ", ".join(res), file=outfile)
+
+    if args.output:
+        outfile.close()
+
+    t_done = time.time()
+    print("compilation took {} s, runnning took {} s.".format(t_compiled-t0, t_done-t_compiled))
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/benchmarks/subset-fails.txt
+++ b/scripts/benchmarks/subset-fails.txt
@@ -1,0 +1,2 @@
+ace-sycl
+minimod-cuda

--- a/scripts/benchmarks/subset.json
+++ b/scripts/benchmarks/subset.json
@@ -1,0 +1,1252 @@
+{
+  "backprop-sycl": [
+    "(?:time = )([0-9.+-e]+)(?:\\(s\\))",
+    [
+      "65536"
+    ]
+  ],
+  "gaussian-sycl": [
+    "(?:Device offloading time )([0-9.+-e]+)(?: \\(us\\))",
+    [
+      "-s",
+      "1000",
+      "-t"
+    ]
+  ],
+  "histogram-sycl": [
+    "(?:Avg time )([0-9.+-e]+)(?: us )",
+    [
+      "--width=3840",
+      "--height=2160"
+    ]
+  ],
+  "mandelbrot-sycl": [
+    "(?:parallel time: )([0-9.+-e]+)(?:s)"
+  ],
+  "nbody-sycl": [
+    "(?:Total Time \\(s\\)[ ]*: )([0-9.+-e]+)",
+    [
+      "20000",
+      "100"
+    ]
+  ],
+  "su3-sycl": [
+    "(?:Total execution time = )([0-9.+-e]+)(?: secs)"
+  ],
+  "adv-sycl": [
+    "(?:elapsed time=)([0-9.+-e]+)(?: )",
+    [
+      "16",
+      "16",
+      "16"
+    ]
+  ],
+  "aidw-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100",
+      "1",
+      "10"
+    ]
+  ],
+  "all-pairs-distance-sycl": [
+    "(?:GPU time \\(w/o? shared memory\\): )([0-9.+-e]+)(?: \\(us\\))",
+    [
+      "1000"
+    ]
+  ],
+  "alp-sycl": [
+    "(?:Total execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "aobench-sycl": [
+    "(?:Average render time: )([0-9.+-e]+)(?: sec)",
+    [
+      "1000"
+    ]
+  ],
+  "aop-sycl": [
+    "(?:elapsed time for each run *: )([0-9.+-e]+)(?:ms)",
+    [
+      "-paths",
+      "200"
+    ]
+  ],
+  "asmooth-sycl": [
+    "(?:Average filtering time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "1",
+      "5",
+      "1"
+    ]
+  ],
+  "asta-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "bezier-surface-sycl": [
+    "(?:device execution time: )([0-9.+-e]+)(?: ms)",
+    [
+      "-m",
+      "10",
+      "-n",
+      "500"
+    ]
+  ],
+  "bilateral-sycl": [
+    "(?:Average kernel execution time \\([1-9]x[1-9]\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "1000",
+      "1000",
+      "1",
+      "5",
+      "1"
+    ]
+  ],
+  "binomial-sycl": [
+    "(?:Total binomialOptionsGPU\\(\\) time: )([0-9.+-e]+)(?: msec)"
+  ],
+  "bitonic-sort-sycl": [
+    "(?:Parallel bitonic time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "22",
+      "1"
+    ]
+  ],
+  "bonds-sycl": [
+    "(?:Processing time on GPU: )([0-9.+-e]+)(?: \\(ms\\))"
+  ],
+  "bsearch-sycl": [
+    "(?:Average device execution time \\(bs[1-9]\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "16384",
+      "1"
+    ]
+  ],
+  "bspline-vgh-sycl": [
+    "(?:Total kernel execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "burger-sycl": [
+    "(?:Total kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "2000"
+    ]
+  ],
+  "cbsfil-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10000",
+      "5"
+    ]
+  ],
+  "ccsd-trpdrv-sycl": [
+    "(?:avg=)([0-9.+-e]+)",
+    [
+      "200",
+      "200"
+    ]
+  ],
+  "clenergy-sycl": [
+    "(?:Kernel time: )([0-9.+-e]+)(?: seconds)"
+  ],
+  "cobahh-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "1000000",
+      "10"
+    ]
+  ],
+  "complex-sycl": [
+    "(?:Average kernel execution time \\([a-z]+\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000000",
+      "10"
+    ]
+  ],
+  "compute-score-sycl": [
+    "(?:Kernel Time = )([0-9.+-e]+)(?: ms)"
+  ],
+  "convolutionSeparable-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "8192",
+      "8192",
+      "5"
+    ]
+  ],
+  "crs-sycl": [
+    "(?:Total elapsed time )([0-9.+-e]+)(?: \\(ms\\))",
+    [
+      "1",
+      "1"
+    ]
+  ],
+  "dp-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000000",
+      "10"
+    ]
+  ],
+  "ecdh-sycl": [
+    "(?:: )([0-9.+-e]+)(?: s)",
+    [
+      "100000000",
+      "10"
+    ]
+  ],
+  "eigenvalue-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "200"
+    ]
+  ],
+  "entropy-sycl": [
+    "(?:execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "2000",
+      "5"
+    ]
+  ],
+  "epistatis-sycl": [
+    "(?:Total offloading time: )([0-9.+-e]+)(?: sec)",
+    [
+      "100",
+      "3000",
+      "10"
+    ]
+  ],
+  "ert-sycl": [
+    "(?:runtime \\([a-z1-9]*\\): )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "128",
+      "1024"
+    ]
+  ],
+  "expdist-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10"
+    ]
+  ],
+  "extend2-sycl": [
+    "(?:Average offload time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "300"
+    ]
+  ],
+  "fft-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "3",
+      "10"
+    ]
+  ],
+  "fsm-sycl": [
+    "([0-9.+-e]+)(?:\\s*#runtime \\[s\\])",
+    [
+      "10000"
+    ]
+  ],
+  "gpp-sycl": [
+    "(?:[*]* Kernel Time Taken [*]*= )([0-9.+-e]+)(?: secs)"
+  ],
+  "ising-sycl": [
+    "(?:elapsed time: )([0-9.+-e]+)(?: sec)"
+  ],
+  "iso2dfd-sycl": [
+    "(?:Elapsed time: )([0-9.+-e]+)(?: ms)",
+    [
+      "5000",
+      "5000",
+      "10"
+    ]
+  ],
+  "jacobi-sycl": [
+    "(?:Run time = )([0-9.+-e]+)(?: seconds)"
+  ],
+  "laplace-sycl": [
+    "(?:Total time: )([0-9.+-e]+)(?: s)"
+  ],
+  "lavaMD-sycl": [
+    "(?:Device offloading time:\\s)([0-9.+-e]+)(?: s)",
+    [
+      "-boxes1d",
+      "16"
+    ]
+  ],
+  "merkle-sycl": [
+    "(?: )([0-9.+-e]+)(?: ms)"
+  ],
+  "minimod-sycl": [
+    "(?:Time kernel: )([0-9.+-e]+)(?: s)"
+  ],
+  "minisweep-sycl": [
+    "(?:time: )([0-9.+-e]+)(?:  )",
+    [
+      "--niterations",
+      "5"
+    ]
+  ],
+  "mnist-sycl": [
+    "(?:Total time \\(learn \\+ test\\) )([0-9.+-e]+)(?: secs)",
+    [
+      "100000"
+    ]
+  ],
+  "mr-sycl": [
+    "(?:\\| *)([0-9.+-e]+)(?: ns *\\|)"
+  ],
+  "murmurhash3-sycl": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100000",
+      "10"
+    ]
+  ],
+  "nbnxm-sycl": [
+    "(?:Total kernel time \\(w/o? shift\\): )([0-9.+-e]+)"
+  ],
+  "page-rank-sycl": [
+    "(?:\"time\": )([0-9.+-e]+)(?: )",
+    [
+      "1000",
+      "1000"
+    ]
+  ],
+  "particle-diffusion-sycl": [
+    "(?:Time: )([0-9.+-e]+)(?: ms)",
+    [
+      "10"
+    ]
+  ],
+  "particlefilter-sycl": [
+    "(?:Device offloading time: )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "-x",
+      "200",
+      "-y",
+      "200",
+      "-z",
+      "200",
+      "-np",
+      "10000"
+    ]
+  ],
+  "pathfinder-sycl": [
+    "(?:Device offloading time = )([0-9.+-e]+)(?:\\(s\\))",
+    [
+      "1000",
+      "1000",
+      "100"
+    ]
+  ],
+  "pns-sycl": [
+    "(?:Total device execution time: )([0-9.+-e]+)(?: s)",
+    [
+      "5000",
+      "100",
+      "100"
+    ]
+  ],
+  "s3d-sycl": [
+    "(?:Total time )([0-9.+-e]+)(?: secs)",
+    [
+      "-s",
+      "3",
+      "-n",
+      "100"
+    ]
+  ],
+  "tridiagonal-sycl": [
+    "(?:Time = )([0-9.+-e]+)(?: s)",
+    [
+      "-num_systems=30000"
+    ]
+  ],
+  "vanGenuchten-sycl": [
+    "(?:Total kernel time : )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100",
+      "100",
+      "100",
+      "10"
+    ]
+  ],
+  "black-scholes-sycl": [
+    "(?:GPU: )([0-9.+-e]+)(?: \\(ms\\))"
+  ],
+  "attention-sycl": [
+    "(?:Device offload time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10000",
+      "5"
+    ]
+  ],
+  "bh-sycl": [
+    "(?:Total kernel execution time: )([0-9.+-e]+)(?: s)",
+    [
+      "300",
+      "30"
+    ]
+  ],
+  "bn-sycl": [
+    "(?:Total duration is )([0-9.+-e]+)(?: seconds)",
+    [
+      "/dev/null"
+    ]
+  ],
+  "sheath-sycl": [
+    "(?:Time per time step: )([0-9.+-e]+)(?: ms)"
+  ],
+  "ace-sycl": [
+    "(?:Offload time = )([0-9.+-e]+)(?:ms)",
+    [
+      "1"
+    ]
+  ],
+  "black-scholes-cuda": [
+    "(?:GPU: )([0-9.+-e]+)(?: \\(ms\\))",
+    [],
+    "BlackScholesEngine"
+  ],
+  "backprop-cuda": [
+    "(?:time = )([0-9.+-e]+)(?:\\(s\\))",
+    [
+      "65536"
+    ]
+  ],
+  "gaussian-cuda": [
+    "(?:Device offloading time )([0-9.+-e]+)(?: \\(us\\))",
+    [
+      "-s",
+      "1000",
+      "-t"
+    ]
+  ],
+  "histogram-cuda": [
+    "(?:Avg time )([0-9.+-e]+)(?: us )",
+    [
+      "--width=3840",
+      "--height=2160"
+    ]
+  ],
+  "nbody-cuda": [
+    "(?:Total Time \\(s\\)[ ]*: )([0-9.+-e]+)",
+    [
+      "20000",
+      "100"
+    ]
+  ],
+  "ace-cuda": [
+    "(?:Offload time = )([0-9.+-e]+)(?:ms)",
+    [
+      "1"
+    ]
+  ],
+  "adv-cuda": [
+    "(?:elapsed time=)([0-9.+-e]+)(?: )",
+    [
+      "32",
+      "32",
+      "32"
+    ]
+  ],
+  "aidw-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100",
+      "1",
+      "10"
+    ]
+  ],
+  "all-pairs-distance-cuda": [
+    "(?:GPU time \\(w/o? shared memory\\): )([0-9.+-e]+)(?: \\(us\\))",
+    [
+      "1000"
+    ]
+  ],
+  "alp-cuda": [
+    "(?:Total execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "asmooth-cuda": [
+    "(?:Average filtering time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "1",
+      "5",
+      "1"
+    ]
+  ],
+  "asta-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "attention-cuda": [
+    "(?:Device offload time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10000",
+      "5"
+    ]
+  ],
+  "bezier-surface-cuda": [
+    "(?:device execution time: )([0-9.+-e]+)(?: ms)",
+    [
+      "-m",
+      "10",
+      "-n",
+      "500"
+    ],
+    "bs"
+  ],
+  "bh-cuda": [
+    "(?:Total kernel execution time: )([0-9.+-e]+)(?: s)",
+    [
+      "300",
+      "30"
+    ]
+  ],
+  "binomial-cuda": [
+    "(?:Total binomialOptionsGPU\\(\\) time: )([0-9.+-e]+)(?: msec)"
+  ],
+  "bitonic-sort-cuda": [
+    "(?:Parallel bitonic time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "22",
+      "1"
+    ]
+  ],
+  "bn-cuda": [
+    "(?:Total duration is )([0-9.+-e]+)(?: seconds)",
+    [
+      "/dev/null"
+    ]
+  ],
+  "bonds-cuda": [
+    "(?:Processing time on GPU: )([0-9.+-e]+)(?: \\(ms\\))"
+  ],
+  "bsearch-cuda": [
+    "(?:Average device execution time \\(bs[1-9]\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "16384",
+      "1"
+    ]
+  ],
+  "bspline-vgh-cuda": [
+    "(?:Total kernel execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "btree-cuda": [
+    "(?:Total device execution time = )([0-9.+-e]+)(?: s)",
+    [
+      "10000000"
+    ]
+  ],
+  "burger-cuda": [
+    "(?:Total kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "2000"
+    ]
+  ],
+  "cbsfil-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10000",
+      "5"
+    ]
+  ],
+  "ccsd-trpdrv-cuda": [
+    "(?:avg=)([0-9.+-e]+)",
+    [
+      "200",
+      "200"
+    ],
+    "test"
+  ],
+  "cobahh-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "1000000",
+      "10"
+    ]
+  ],
+  "complex-cuda": [
+    "(?:Average kernel execution time \\([a-z]+\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000000",
+      "10"
+    ]
+  ],
+  "compute-score-cuda": [
+    "(?:Kernel Time = )([0-9.+-e]+)(?: ms)"
+  ],
+  "convolutionSeparable-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "8192",
+      "8192",
+      "5"
+    ]
+  ],
+  "crs-cuda": [
+    "(?:Total elapsed time )([0-9.+-e]+)(?: \\(ms\\))",
+    [
+      "1",
+      "1"
+    ]
+  ],
+  "dp-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000000",
+      "10"
+    ]
+  ],
+  "ecdh-cuda": [
+    "(?:: )([0-9.+-e]+)(?: s)",
+    [
+      "100000000",
+      "10"
+    ]
+  ],
+  "eigenvalue-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "200"
+    ]
+  ],
+  "entropy-cuda": [
+    "(?:execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "2000",
+      "5"
+    ]
+  ],
+  "epistatis-cuda": [
+    "(?:Total offloading time: )([0-9.+-e]+)(?: sec)",
+    [
+      "100",
+      "3000",
+      "10"
+    ]
+  ],
+  "ert-cuda": [
+    "(?:runtime \\([a-z1-9]*\\): )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "128",
+      "1024"
+    ]
+  ],
+  "expdist-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10"
+    ]
+  ],
+  "extend2-cuda": [
+    "(?:Average offload time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "300"
+    ]
+  ],
+  "fft-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "3",
+      "10"
+    ]
+  ],
+  "fsm-cuda": [
+    "([0-9.+-e]+)(?:\\s*#runtime \\[s\\])",
+    [
+      "10000"
+    ]
+  ],
+  "ising-cuda": [
+    "(?:elapsed time: )([0-9.+-e]+)(?: sec)"
+  ],
+  "jacobi-cuda": [
+    "(?:Run time = )([0-9.+-e]+)(?: seconds)"
+  ],
+  "laplace-cuda": [
+    "(?:Total time: )([0-9.+-e]+)(?: s)"
+  ],
+  "lavaMD-cuda": [
+    "(?:Device offloading time:\\s)([0-9.+-e]+)(?: s)",
+    [
+      "-boxes1d",
+      "16"
+    ]
+  ],
+  "minimod-cuda": [
+    "(?:Time kernel: )([0-9.+-e]+)(?: s)"
+  ],
+  "minisweep-cuda": [
+    "(?:time: )([0-9.+-e]+)(?:  )",
+    [
+      "--niterations",
+      "5"
+    ]
+  ],
+  "mnist-cuda": [
+    "(?:Total time \\(learn \\+ test\\) )([0-9.+-e]+)(?: secs)",
+    [
+      "100000"
+    ]
+  ],
+  "mr-cuda": [
+    "(?:\\| *)([0-9.+-e]+)(?: ns *\\|)"
+  ],
+  "murmurhash3-cuda": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100000",
+      "10"
+    ]
+  ],
+  "myocyte-cuda": [
+    "([0-9.+-e]+)(?: s, [0-9.+-e]+ % : RUN COMPUTATION)",
+    [
+      "100"
+    ]
+  ],
+  "page-rank-cuda": [
+    "(?:\"time\": )([0-9.+-e]+)(?: )",
+    [
+      "1000",
+      "1000"
+    ],
+    "page-rank"
+  ],
+  "particle-diffusion-cuda": [
+    "(?:Time: )([0-9.+-e]+)(?: ms)",
+    [
+      "10"
+    ],
+    "motionsim"
+  ],
+  "particlefilter-cuda": [
+    "(?:Device offloading time: )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "-x",
+      "200",
+      "-y",
+      "200",
+      "-z",
+      "200",
+      "-np",
+      "10000"
+    ]
+  ],
+  "pathfinder-cuda": [
+    "(?:Device offloading time = )([0-9.+-e]+)(?:\\(s\\))",
+    [
+      "1000",
+      "1000",
+      "100"
+    ]
+  ],
+  "s3d-cuda": [
+    "(?:Total time )([0-9.+-e]+)(?: secs)",
+    [
+      "-s",
+      "3",
+      "-n",
+      "100"
+    ],
+    "s3d"
+  ],
+  "sheath-cuda": [
+    "(?:Time per time step: )([0-9.+-e]+)(?: ms)"
+  ],
+  "tridiagonal-cuda": [
+    "(?:Time = )([0-9.+-e]+)(?: s)",
+    [
+      "-num_systems=30000"
+    ]
+  ],
+  "vanGenuchten-cuda": [
+    "(?:Total kernel time : )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100",
+      "100",
+      "100",
+      "10"
+    ]
+  ],
+  "su3-cuda": [
+    "(?:Total execution time = )([0-9.+-e]+)(?: secs)"
+  ],
+  "aobench-cuda": [
+    "(?:Average render time: )([0-9.+-e]+)(?: sec)",
+    [
+      "1000"
+    ],
+    "ao"
+  ],
+  "aop-cuda": [
+    "(?:elapsed time for each run *: )([0-9.+-e]+)(?:ms)",
+    [
+      "-paths",
+      "200"
+    ]
+  ],
+  "clenergy-cuda": [
+    "(?:Kernel time: )([0-9.+-e]+)(?: seconds)",
+    [],
+    "clenergy"
+  ],
+  "pns-cuda": [
+    "(?:Total device execution time: )([0-9.+-e]+)(?: s)",
+    [
+      "5000",
+      "100",
+      "100"
+    ]
+  ],
+  "black-scholes-hip": [
+    "(?:GPU: )([0-9.+-e]+)(?: \\(ms\\))"
+  ],
+  "backprop-hip": [
+    "(?:time = )([0-9.+-e]+)(?:\\(s\\))",
+    [
+      "65536"
+    ]
+  ],
+  "gaussian-hip": [
+    "(?:Device offloading time )([0-9.+-e]+)(?: \\(us\\))",
+    [
+      "-s",
+      "1000",
+      "-t"
+    ]
+  ],
+  "histogram-hip": [
+    "(?:Avg time )([0-9.+-e]+)(?: us )",
+    [
+      "--width=3840",
+      "--height=2160"
+    ]
+  ],
+  "mandelbrot-hip": [
+    "(?:parallel time: )([0-9.+-e]+)(?:s)"
+  ],
+  "nbody-hip": [
+    "(?:Total Time \\(s\\)[ ]*: )([0-9.+-e]+)",
+    [
+      "20000",
+      "100"
+    ]
+  ],
+  "su3-hip": [
+    "(?:Total execution time = )([0-9.+-e]+)(?: secs)"
+  ],
+  "ace-hip": [
+    "(?:Offload time = )([0-9.+-e]+)(?:ms)",
+    [
+      "1"
+    ]
+  ],
+  "adv-hip": [
+    "(?:elapsed time=)([0-9.+-e]+)(?: )",
+    [
+      "32",
+      "32",
+      "32"
+    ]
+  ],
+  "aidw-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100",
+      "0",
+      "10"
+    ]
+  ],
+  "all-pairs-distance-hip": [
+    "(?:GPU time \\(w/o? shared memory\\): )([0-9.+-e]+)(?: \\(us\\))",
+    [
+      "1000"
+    ]
+  ],
+  "alp-hip": [
+    "(?:Total execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "aobench-hip": [
+    "(?:Average render time: )([0-9.+-e]+)(?: sec)",
+    [
+      "1000"
+    ]
+  ],
+  "aop-hip": [
+    "(?:elapsed time for each run *: )([0-9.+-e]+)(?:ms)",
+    [
+      "-paths",
+      "200"
+    ]
+  ],
+  "asmooth-hip": [
+    "(?:Average filtering time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "1",
+      "5",
+      "1"
+    ]
+  ],
+  "asta-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "attention-hip": [
+    "(?:Device offload time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10000",
+      "5"
+    ]
+  ],
+  "bezier-surface-hip": [
+    "(?:device execution time: )([0-9.+-e]+)(?: ms)",
+    [
+      "-m",
+      "10",
+      "-n",
+      "500"
+    ]
+  ],
+  "bh-hip": [
+    "(?:Total kernel execution time: )([0-9.+-e]+)(?: s)",
+    [
+      "300",
+      "30"
+    ]
+  ],
+  "bilateral-hip": [
+    "(?:Average kernel execution time \\([1-9]x[1-9]\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "1000",
+      "1000",
+      "1",
+      "5",
+      "1"
+    ]
+  ],
+  "binomial-hip": [
+    "(?:Total binomialOptionsGPU\\(\\) time: )([0-9.+-e]+)(?: msec)"
+  ],
+  "bitonic-sort-hip": [
+    "(?:Parallel bitonic time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "22",
+      "1"
+    ]
+  ],
+  "bn-hip": [
+    "(?:Total duration is )([0-9.+-e]+)(?: seconds)",
+    [
+      "/dev/null"
+    ]
+  ],
+  "bonds-hip": [
+    "(?:Processing time on GPU: )([0-9.+-e]+)(?: \\(ms\\))"
+  ],
+  "bsearch-hip": [
+    "(?:Average device execution time \\(bs[1-9]\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "16384",
+      "1"
+    ]
+  ],
+  "bspline-vgh-hip": [
+    "(?:Total kernel execution time )([0-9.+-e]+)(?: \\(s\\))"
+  ],
+  "btree-hip": [
+    "(?:Total device execution time = )([0-9.+-e]+)(?: s)",
+    [
+      "10000000"
+    ]
+  ],
+  "burger-hip": [
+    "(?:Total kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "2000"
+    ]
+  ],
+  "cbsfil-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10000",
+      "5"
+    ]
+  ],
+  "ccsd-trpdrv-hip": [
+    "(?:avg=)([0-9.+-e]+)",
+    [
+      "200",
+      "200"
+    ]
+  ],
+  "clenergy-hip": [
+    "(?:Kernel time: )([0-9.+-e]+)(?: seconds)"
+  ],
+  "cobahh-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "1000000",
+      "10"
+    ]
+  ],
+  "complex-hip": [
+    "(?:Average kernel execution time \\([a-z]+\\) )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000000",
+      "10"
+    ]
+  ],
+  "compute-score-hip": [
+    "(?:Kernel Time = )([0-9.+-e]+)(?: ms)"
+  ],
+  "convolutionSeparable-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "8192",
+      "8192",
+      "5"
+    ]
+  ],
+  "crs-hip": [
+    "(?:Total elapsed time )([0-9.+-e]+)(?: \\(ms\\))",
+    [
+      "1",
+      "1"
+    ]
+  ],
+  "dp-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000000",
+      "10"
+    ]
+  ],
+  "ecdh-hip": [
+    "(?:: )([0-9.+-e]+)(?: s)",
+    [
+      "100000000",
+      "10"
+    ]
+  ],
+  "eigenvalue-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "200"
+    ]
+  ],
+  "entropy-hip": [
+    "(?:execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "2000",
+      "2000",
+      "5"
+    ]
+  ],
+  "epistatis-hip": [
+    "(?:Total offloading time: )([0-9.+-e]+)(?: sec)",
+    [
+      "100",
+      "3000",
+      "10"
+    ]
+  ],
+  "ert-hip": [
+    "(?:runtime \\([a-z1-9]*\\): )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "128",
+      "1024"
+    ]
+  ],
+  "expdist-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "10000",
+      "10"
+    ]
+  ],
+  "extend2-hip": [
+    "(?:Average offload time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "300"
+    ]
+  ],
+  "fft-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "3",
+      "10"
+    ]
+  ],
+  "fsm-hip": [
+    "([0-9.+-e]+)(?:\\s*#runtime \\[s\\])",
+    [
+      "10000"
+    ]
+  ],
+  "gpp-hip": [
+    "(?:[*]* Kernel Time Taken [*]*= )([0-9.+-e]+)(?: secs)"
+  ],
+  "ising-hip": [
+    "(?:elapsed time: )([0-9.+-e]+)(?: sec)"
+  ],
+  "iso2dfd-hip": [
+    "(?:Elapsed time: )([0-9.+-e]+)(?: ms)",
+    [
+      "5000",
+      "5000",
+      "10"
+    ]
+  ],
+  "jacobi-hip": [
+    "(?:Run time = )([0-9.+-e]+)(?: seconds)"
+  ],
+  "keccaktreehash-hip": [
+    "(?:GPU speed : )([0-9.+-e]+)(?: kB/s)",
+    [
+      "100",
+      "100",
+      "100"
+    ],
+    {
+      "invert": true
+    }
+  ],
+  "laplace-hip": [
+    "(?:Total time: )([0-9.+-e]+)(?: s)"
+  ],
+  "lavaMD-hip": [
+    "(?:Device offloading time:\\s)([0-9.+-e]+)(?: s)",
+    [
+      "-boxes1d",
+      "16"
+    ]
+  ],
+  "merkle-hip": [
+    "(?: )([0-9.+-e]+)(?: ms)"
+  ],
+  "minimod-hip": [
+    "(?:Time kernel: )([0-9.+-e]+)(?: s)"
+  ],
+  "minisweep-hip": [
+    "(?:time: )([0-9.+-e]+)(?:  )",
+    [
+      "--niterations",
+      "5"
+    ]
+  ],
+  "mnist-hip": [
+    "(?:Total time \\(learn \\+ test\\) )([0-9.+-e]+)(?: secs)",
+    [
+      "100000"
+    ]
+  ],
+  "mr-hip": [
+    "(?:\\| *)([0-9.+-e]+)(?: ns *\\|)"
+  ],
+  "murmurhash3-hip": [
+    "(?:Average kernel execution time )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100000",
+      "10"
+    ]
+  ],
+  "myocyte-hip": [
+    "(?:Device offloading time:\n)([0-9.+-e]+)(?: s)",
+    [
+      "-time",
+      "100"
+    ],
+    "myocyte.out"
+  ],
+  "nbnxm-hip": [
+    "(?:Total kernel time \\(w/o? shift\\): )([0-9.+-e]+)"
+  ],
+  "page-rank-hip": [
+    "(?:\"time\": )([0-9.+-e]+)(?: )",
+    [
+      "1000",
+      "1000"
+    ]
+  ],
+  "particle-diffusion-hip": [
+    "(?:Time: )([0-9.+-e]+)(?: ms)",
+    [
+      "10"
+    ]
+  ],
+  "particlefilter-hip": [
+    "(?:Device offloading time: )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "-x",
+      "200",
+      "-y",
+      "200",
+      "-z",
+      "200",
+      "-np",
+      "10000"
+    ]
+  ],
+  "pathfinder-hip": [
+    "(?:Device offloading time = )([0-9.+-e]+)(?:\\(s\\))",
+    [
+      "1000",
+      "1000",
+      "100"
+    ]
+  ],
+  "pns-hip": [
+    "(?:Total device execution time: )([0-9.+-e]+)(?: s)",
+    [
+      "5000",
+      "100",
+      "100"
+    ]
+  ],
+  "s3d-hip": [
+    "(?:Total time )([0-9.+-e]+)(?: secs)",
+    [
+      "-s",
+      "3",
+      "-n",
+      "100"
+    ]
+  ],
+  "sheath-hip": [
+    "(?:Time per time step: )([0-9.+-e]+)(?: ms)"
+  ],
+  "tridiagonal-hip": [
+    "(?:Time = )([0-9.+-e]+)(?: s)",
+    [
+      "-num_systems=30000"
+    ]
+  ],
+  "vanGenuchten-hip": [
+    "(?:Total kernel time : )([0-9.+-e]+)(?: \\(s\\))",
+    [
+      "100",
+      "100",
+      "100",
+      "10"
+    ]
+  ]
+}


### PR DESCRIPTION
This patch adds python scripts that help build, run and gather results from the benchmarks. As well as a basic script to compare results from two different runs.

It works with a `.json` file containing the benchmark names, a regex to find the timings in the benchmark output and optional arguments that must be provided to the benchmark binary. The `subset.json` contains roughly 70 of the benchmarks for cuda, hip and sycl at the moment, more work would be required to support the rest of the benchmarks. In addition if there are failing benchmarks in the `.json` list, an additional text file can be provided with a list of benchmarks to skip when running all of them. Benchmarks in the text file can still be run explicitely.

For example to run all the SYCL benchmarks and then all the CUDA benchmarks and compare the two:

```
./autohecbench.py sycl -o sycl.csv
./autohecbench.py cuda -o cuda.csv
./autohecbench-compare.py sycl.csv cuda.csv
```

It can also be used to run a single benchmark:

```
./autohecbench.py mandelbrot-sycl --verbose
```

By default it will run a warmup iteration before running each benchmark, and it is possible to run the benchmarks multiple times with `-r`:

```
./autohecbench.py mandelbrot-sycl -r 20 -o mandel.csv
```

And it also has options to pick the SM version or HIP architecture and a few other parameters.

Credits to @t4c1 for the initial benchmark data list

I'm not sure if this is the best place to keep this or if you have your own scripts but we thought this may be helpful to other people as well as we've been using it to test DPC++ changes against some of the benchmarks here.