### PR TITLE
Align Makefile run target arguments across APIs

### DIFF
--- a/aop-omp/Makefile
+++ b/aop-omp/Makefile
@@ -59,5 +59,5 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program)
+	./$(program) -runs 100
 

--- a/atomicAggregate-sycl/Makefile
+++ b/atomicAggregate-sycl/Makefile
@@ -73,4 +73,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) 100
+	./$(program) 1000

--- a/gc-cuda/Makefile
+++ b/gc-cuda/Makefile
@@ -53,4 +53,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) ../mis-cuda/internet.egr
+	./$(program) ../mis-cuda/internet.egr 100

--- a/gru-sycl/Makefile
+++ b/gru-sycl/Makefile
@@ -75,4 +75,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) 100000
+	./$(program) 102400 1024 100

--- a/inversek2j-omp/Makefile
+++ b/inversek2j-omp/Makefile
@@ -59,4 +59,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) ../inverse2kj-sycl/coord_in.txt 100000
+	./$(program) ../inversek2j-sycl/coord_in.txt 100000

--- a/ising-sycl/Makefile
+++ b/ising-sycl/Makefile
@@ -73,4 +73,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) -x 5120 -y 5120 -w 100 -n 100
+	./$(program) -x 5120 -y 5120 -w 10 -n 1000

--- a/mandelbrot-cuda/Makefile
+++ b/mandelbrot-cuda/Makefile
@@ -52,4 +52,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) 100
+	./$(program) 1000

--- a/p4-omp/Makefile
+++ b/p4-omp/Makefile
@@ -58,4 +58,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) 100000
+	./$(program) 10000

--- a/scan2-hip/Makefile
+++ b/scan2-hip/Makefile
@@ -52,4 +52,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program) 100 33554432 256
+	./$(program) 1000 33554432 256


### PR DESCRIPTION
Ensure that `make run` executes comparable commands for each API (cuda/hip/omp/sycl) for a given benchmark.

Found the differences between APIs using `grep` + a python script parsing the run commands.

In a few cases this fixes a broken command (insufficient number of arguments, typo in a file name), in other cases it simply aligns the number of repetitions or the size of the problem with the benchmark versions for other APIs.