### PR TITLE
Update benchmark to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ Each benchmark falls into a single category. While such classification is not ac
     It can also be used to run a single benchmark:
 
     ```
-    ./autohecbench.py mandelbrot-sycl --verbose
+    ./autohecbench.py backprop-sycl --verbose
     ```
 
     By default it will run a warmup iteration before running each benchmark,
     and it is possible to run the benchmarks multiple times with `-r`:
     ```
-    ./autohecbench.py mandelbrot-sycl -r 20 -o mandel.csv
+    ./autohecbench.py backprop-sycl -r 20 -o mandel.csv
     ```
 
     And it also has options to pick the SM version or HIP architecture and a


### PR DESCRIPTION
`mandelbrot-sycl` is not in the json set and using it results in an error. Point to `backprop-sycl` instead.
This saves users debugging, rather cryptic, error they would get:
```
./scripts/autohecbench.py mandelbrot-sycl --verbose
```
```
Traceback (most recent call last):
  File "/home/jakubchlanda/Projects/oneAPI/jchlanda/HeCBench/./scripts/autohecbench.py", line 188, in <module>
    main()
  File "/home/jakubchlanda/Projects/oneAPI/jchlanda/HeCBench/./scripts/autohecbench.py", line 148, in main
    benches.append(Benchmark(args, b, *benchmarks[b]))
KeyError: 'mandelbrot-sycl'

```