### PR TITLE
Fix compiler errors and warnings for newer DPC++ versions

### DIFF
--- a/conversion-sycl/main.cpp
+++ b/conversion-sycl/main.cpp
@@ -1,39 +1,36 @@
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdio>
-#include <CL/sycl.hpp>
-#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+#include <sycl/sycl.hpp>
 
-using sycl::ext::oneapi::experimental::bfloat16;
-
-using namespace std;
-using namespace sycl;
+using sycl::ext::oneapi::bfloat16;
 
 template <typename Td, typename Ts>
-void convert(queue &q, int nelems, int niters)
+void convert(sycl::queue &q, int nelems, int niters)
 {
-  Ts *src = (Ts*) malloc_shared (nelems * sizeof(Ts), q);
-  Td *dst = (Td*) malloc_shared (nelems * sizeof(Td), q);
+  Ts *src = sycl::malloc_shared<Ts>(nelems, q);
+  Td *dst = sycl::malloc_shared<Td>(nelems, q);
 
-  const size_t ls = std::min((size_t)nelems, (size_t)256);
+  const size_t ls = std::min<std::size_t>(nelems, 256);
   const size_t gs = nelems % ls ? (nelems / ls + 1) * ls : nelems;
-  range<1> gws (gs);
-  range<1> lws (ls);
+  sycl::range<1> gws (gs);
+  sycl::range<1> lws (ls);
 
   // Warm-up run
-  q.submit([&](handler &cgh) {
-    cgh.parallel_for(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-      int i = item.get_global_id(0);
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+      const int i = item.get_global_id(0);
       if (i < nelems) {
         dst[i] = static_cast<Td>(src[i]);
       }
     });
   }).wait();
 
-  auto start = std::chrono::high_resolution_clock::now();
+  const auto start = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < niters; i++) {
-    q.submit([&](handler &cgh) {
-      cgh.parallel_for(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
+    q.submit([&](sycl::handler &cgh) {
+      cgh.parallel_for(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
         if (i < nelems) {
           dst[i] = static_cast<Td>(src[i]);
@@ -42,96 +39,95 @@ void convert(queue &q, int nelems, int niters)
     });
   }
   q.wait();
-  auto end = std::chrono::high_resolution_clock::now();
-  double time = std::chrono::duration_cast<std::chrono::microseconds>
+  const auto end = std::chrono::high_resolution_clock::now();
+  const double time = std::chrono::duration_cast<std::chrono::microseconds>
                 (end - start).count() / niters / 1.0e6f;
-  double size = (sizeof(Td) + sizeof(Ts)) * nelems / 1e9;
-  printf("size(GB):%.2f, average time(sec):%f, BW:%f\n", size, time, size / time);
+  const double size = (sizeof(Td) + sizeof(Ts)) * nelems / 1e9;
+  std::printf("size(GB):%.2f, average time(sec):%f, BW:%f\n", size, time, size / time);
 
-  free(src, q);
-  free(dst, q);
+  sycl::free(src, q);
+  sycl::free(dst, q);
 }
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {
-    printf("Usage: %s <repeat>\n", argv[0]);
+    std::printf("Usage: %s <repeat>\n", argv[0]);
     return 1;
   }
-  const int niters = atoi(argv[1]);
+  const int niters = std::stoi(argv[1]);
   const int nelems = 1024 * 1024 * 256;
 
 #ifdef USE_GPU
-  gpu_selector dev_sel;
+  sycl::queue q(sycl::gpu_selector_v);
 #else
-  cpu_selector dev_sel;
+  sycl::queue q(sycl::cpu_selector_v);
 #endif
-  queue q(dev_sel);
 
-  printf("bfloat16 -> half\n");
-  convert<half, bfloat16>(q, nelems, niters); 
-  printf("bfloat16 -> float\n");
-  convert<float, bfloat16>(q, nelems, niters); 
-  printf("bfloat16 -> int\n");
-  convert<int, bfloat16>(q, nelems, niters); 
-  printf("bfloat16 -> char\n");
-  convert<char, bfloat16>(q, nelems, niters); 
-  printf("bfloat16 -> uchar\n");
-  convert<uchar, bfloat16>(q, nelems, niters); 
+  std::printf("bfloat16 -> half\n");
+  convert<sycl::half, bfloat16>(q, nelems, niters);
+  std::printf("bfloat16 -> float\n");
+  convert<float, bfloat16>(q, nelems, niters);
+  std::printf("bfloat16 -> int\n");
+  convert<int, bfloat16>(q, nelems, niters);
+  std::printf("bfloat16 -> char\n");
+  convert<char, bfloat16>(q, nelems, niters);
+  std::printf("bfloat16 -> unsigned char\n");
+  convert<unsigned char, bfloat16>(q, nelems, niters);
 
-  printf("half -> half\n");
-  convert<half, half>(q, nelems, niters); 
-  printf("half -> float\n");
-  convert<float, half>(q, nelems, niters); 
-  printf("half -> int\n");
-  convert<int, half>(q, nelems, niters); 
-  printf("half -> char\n");
-  convert<char, half>(q, nelems, niters); 
-  printf("half -> uchar\n");
-  convert<uchar, half>(q, nelems, niters); 
+  std::printf("half -> half\n");
+  convert<sycl::half, sycl::half>(q, nelems, niters);
+  std::printf("half -> float\n");
+  convert<float, sycl::half>(q, nelems, niters);
+  std::printf("half -> int\n");
+  convert<int, sycl::half>(q, nelems, niters);
+  std::printf("half -> char\n");
+  convert<char, sycl::half>(q, nelems, niters);
+  std::printf("half -> unsigned char\n");
+  convert<unsigned char, sycl::half>(q, nelems, niters);
 
-  printf("float -> float\n");
-  convert<float, float>(q, nelems, niters); 
-  printf("float -> half\n");
-  convert<half, float>(q, nelems, niters); 
-  printf("float -> int\n");
-  convert<int, float>(q, nelems, niters); 
-  printf("float -> char\n");
-  convert<char, float>(q, nelems, niters); 
-  printf("float -> uchar\n");
-  convert<uchar, float>(q, nelems, niters); 
+  std::printf("float -> float\n");
+  convert<float, float>(q, nelems, niters);
+  std::printf("float -> half\n");
+  convert<sycl::half, float>(q, nelems, niters);
+  std::printf("float -> int\n");
+  convert<int, float>(q, nelems, niters);
+  std::printf("float -> char\n");
+  convert<char, float>(q, nelems, niters);
+  std::printf("float -> unsigned char\n");
+  convert<unsigned char, float>(q, nelems, niters);
 
-  printf("int -> int\n");
-  convert<int, int>(q, nelems, niters); 
-  printf("int -> float\n");
-  convert<float, int>(q, nelems, niters); 
-  printf("int -> half\n");
-  convert<half, int>(q, nelems, niters); 
-  printf("int -> char\n");
-  convert<char, int>(q, nelems, niters); 
-  printf("int -> uchar\n");
-  convert<uchar, int>(q, nelems, niters); 
+  std::printf("int -> int\n");
+  convert<int, int>(q, nelems, niters);
+  std::printf("int -> float\n");
+  convert<float, int>(q, nelems, niters);
+  std::printf("int -> half\n");
+  convert<sycl::half, int>(q, nelems, niters);
+  std::printf("int -> char\n");
+  convert<char, int>(q, nelems, niters);
+  std::printf("int -> unsigned char\n");
+  convert<unsigned char, int>(q, nelems, niters);
 
-  printf("char -> int\n");
-  convert<int, char>(q, nelems, niters); 
-  printf("char -> float\n");
-  convert<float, char>(q, nelems, niters); 
-  printf("char -> half\n");
-  convert<half, char>(q, nelems, niters); 
-  printf("char -> char\n");
-  convert<char, char>(q, nelems, niters); 
-  printf("char -> uchar\n");
-  convert<uchar, char>(q, nelems, niters); 
+  std::printf("char -> int\n");
+  convert<int, char>(q, nelems, niters);
+  std::printf("char -> float\n");
+  convert<float, char>(q, nelems, niters);
+  std::printf("char -> half\n");
+  convert<sycl::half, char>(q, nelems, niters);
+  std::printf("char -> char\n");
+  convert<char, char>(q, nelems, niters);
+  std::printf("char -> unsigned char\n");
+  convert<unsigned char, char>(q, nelems, niters);
 
-  printf("uchar -> int\n");
-  convert<int, uchar>(q, nelems, niters); 
-  printf("uchar -> float\n");
-  convert<float, uchar>(q, nelems, niters); 
-  printf("uchar -> half\n");
-  convert<half, uchar>(q, nelems, niters); 
-  printf("uchar -> char\n");
-  convert<char, uchar>(q, nelems, niters); 
-  printf("uchar -> uchar\n");
-  convert<uchar, uchar>(q, nelems, niters); 
+  std::printf("unsigned char -> int\n");
+  convert<int, unsigned char>(q, nelems, niters);
+  std::printf("unsigned char -> float\n");
+  convert<float, unsigned char>(q, nelems, niters);
+  std::printf("unsigned char -> half\n");
+  convert<sycl::half, unsigned char>(q, nelems, niters);
+  std::printf("unsigned char -> char\n");
+  convert<char, unsigned char>(q, nelems, niters);
+  std::printf("unsigned char -> unsigned char\n");
+  convert<unsigned char, unsigned char>(q, nelems, niters);
 
   return 0;
 }

--- a/frechet-sycl/norm1.h
+++ b/frechet-sycl/norm1.h
@@ -1,3 +1,5 @@
+#include <sycl/sycl.hpp>
+
 double norm1(int i, int j, const double *c1, const double *c2)
 {
   double dist, diff; /* Temp variables for simpler computations */
@@ -34,7 +36,7 @@ double recursive_norm1(int i, int j, int n_2, double *ca,
   double *ca_ij = ca + (i - 1)*n_2 + (j - 1);
 
   /* This implements the algorithm from [1] */
-  if (*ca_ij > -1.0) 
+  if (*ca_ij > -1.0)
   {
     return *ca_ij;
   }
@@ -68,7 +70,7 @@ double recursive_norm1(int i, int j, int n_2, double *ca,
 }
 
 void distance_norm1 (
-  nd_item<2> &item,
+  sycl::nd_item<2> &item,
   int n_1, int n_2,
   double *__restrict ca,
   const double *__restrict c1,

--- a/frechet-sycl/norm2.h
+++ b/frechet-sycl/norm2.h
@@ -1,3 +1,5 @@
+#include <sycl/sycl.hpp>
+
 double norm2(int i, int j, const double *c1, const double *c2)
 {
   double dist, diff; /* Temp variables for simpler computations */
@@ -37,7 +39,7 @@ double recursive_norm2(int i, int j, int n_2, double *ca,
   double *ca_ij = ca + (i - 1)*n_2 + (j - 1);
 
   /* This implements the algorithm from [1] */
-  if (*ca_ij > -1.0) 
+  if (*ca_ij > -1.0)
   {
     return *ca_ij;
   }
@@ -71,7 +73,7 @@ double recursive_norm2(int i, int j, int n_2, double *ca,
 }
 
 void distance_norm2 (
-  nd_item<2> &item,
+  sycl::nd_item<2> &item,
   int n_1, int n_2,
   double *__restrict ca,
   const double *__restrict c1,

--- a/frechet-sycl/norm3.h
+++ b/frechet-sycl/norm3.h
@@ -1,3 +1,5 @@
+#include <sycl/sycl.hpp>
+
 double norm3(int i, int j, const double *c1, const double *c2)
 {
   double dist, diff; /* Temp variables for simpler computations */
@@ -34,7 +36,7 @@ double recursive_norm3(int i, int j, int n_2, double *ca,
   double *ca_ij = ca + (i - 1)*n_2 + (j - 1);
 
   /* This implements the algorithm from [1] */
-  if (*ca_ij > -1.0) 
+  if (*ca_ij > -1.0)
   {
     return *ca_ij;
   }
@@ -68,7 +70,7 @@ double recursive_norm3(int i, int j, int n_2, double *ca,
 }
 
 void distance_norm3 (
-  nd_item<2> &item,
+  sycl::nd_item<2> &item,
   int n_1, int n_2,
   double *__restrict ca,
   const double *__restrict c1,

--- a/hbc-sycl/main.cpp
+++ b/hbc-sycl/main.cpp
@@ -13,11 +13,10 @@ int main(int argc, char *argv[])
   int max_threads_per_block, number_of_SMs;
 
 #ifdef USE_GPU
-  sycl::gpu_selector dev_sel;
+    sycl::queue q(sycl::gpu_selector_v);
 #else
-  sycl::cpu_selector dev_sel;
+    sycl::queue q(sycl::cpu_selector_v);
 #endif
-  sycl::queue q(dev_sel);
 
   query_device(q, max_threads_per_block,number_of_SMs,op);
 

--- a/hbc-sycl/util.h
+++ b/hbc-sycl/util.h
@@ -4,15 +4,16 @@
 #include <iostream>
 #include <cstdlib>
 #include <cmath>
+#include <set>
 #include <getopt.h>
 #include "parse.h"
-#include "common.h"  // sycl queue
+#include <sycl/sycl.hpp>
 
 //Command line parsing
 class program_options
 {
   public:
-    program_options() : infile(NULL), verify(false), printBCscores(false), 
+    program_options() : infile(NULL), verify(false), printBCscores(false),
                         scorefile(NULL), device(-1), approx(false), k(256) {}
 
     char *infile;

--- a/lci-sycl/kernels.h
+++ b/lci-sycl/kernels.h
@@ -1,10 +1,12 @@
+#include <sycl/sycl.hpp>
+
 #define one_over_theta0  (5.0/(2.0*pow(M_PI,4)))
 #define kappa (pow(M_PI,2)/3.0 - 2 * 1.2020569031595942)
 
 /*
  there are some limitation on L_max
  due to GSL's factorial N! is only defined in GSL for N<=170
- thus L_max < 85 
+ thus L_max < 85
  */
 const int L_max=64;
 
@@ -27,14 +29,14 @@ double alpha(int l, const double* dftab, const double* ftab)
 {
   if(l<0) return 0.0;
   if(l==0) return 1.0;
-  else 
+  else
     return dftab[2*l-1] / ftab[l];
 }
 
 double Omega(int l, int m, int n, const double* dftab, const double* ftab)
 {
   return alpha(m-n+l, dftab, ftab) * alpha(m+n-l, dftab, ftab) *
-         alpha(n-m+l, dftab, ftab) / alpha(m+n+l, dftab, ftab) * 
+         alpha(n-m+l, dftab, ftab) / alpha(m+n+l, dftab, ftab) *
          (4*l+1) / (2.0*(n+m+l)+1) ;
 }
 
@@ -55,7 +57,7 @@ double Sum_NL(int l, const double c[])
   return sum * (2*l-1)*(l+1)*c[l]/3.0;
 }
 
-void RHS_f (nd_item<1> &item, const double* dftab, const double* ftab,
+void RHS_f (sycl::nd_item<1> &item, const double* dftab, const double* ftab,
             double t, const double *c, double *RHS)
 {
   int l = item.get_local_id(0) + 1;
@@ -66,16 +68,16 @@ void RHS_f (nd_item<1> &item, const double* dftab, const double* ftab,
   {
     double B_bar = B(l) - 4.0/3.0;
     double LHS_119;
-    if (l > 1) 
+    if (l > 1)
       LHS_119 = 1.0/t * ( U(l) * c[l+1] + (B_bar - 2.0/15.0 * c[1]) + C(l) * c[l-1]);
-    else 
+    else
       LHS_119 = 1.0/t * ( U(1) * c[2] + (B_bar - 2.0/15.0 * c[1]) + C(1));
 
     double Sum1 = Sum_Omega(l, c, dftab, ftab);
     double Sum2 = Sum_NL(l, c);
 
     double RHS_119 = - T*one_over_theta0 *(
-        (kappa + M_PI*M_PI*l*(2*l+1)/3.0)*c[l] + 
+        (kappa + M_PI*M_PI*l*(2*l+1)/3.0)*c[l] +
          kappa*Sum1 + kappa*Sum2);
 
     RHS[l] = -LHS_119 + RHS_119;

--- a/logan-sycl/src/logan_functions.cpp
+++ b/logan-sycl/src/logan_functions.cpp
@@ -585,9 +585,7 @@ void extendSeedL(std::vector<SeedL> &seeds,
     sycl::range<1> lws (n_threads);
 
     stream_l[i].submit([&](sycl::handler &cgh) {
-      sycl::accessor<short, 1,
-                     sycl::access::mode::read_write,
-                     sycl::access::target::local> sm (sycl::range<1>(n_threads), cgh);
+      sycl::local_accessor<short> sm (sycl::range<1>(n_threads), cgh);
 
       auto seed_d_l_i = seed_d_l[i];
       auto prefQ_d_i = prefQ_d[i];
@@ -610,9 +608,7 @@ void extendSeedL(std::vector<SeedL> &seeds,
     });
 
     stream_r[i].submit([&](sycl::handler &cgh) {
-      sycl::accessor<short, 1,
-                     sycl::access::mode::read_write,
-                     sycl::access::target::local> sm (sycl::range<1>(n_threads), cgh);
+      sycl::local_accessor<short> sm (sycl::range<1>(n_threads), cgh);
 
       auto seed_d_r_i = seed_d_r[i];
       auto suffQ_d_i = suffQ_d[i];

--- a/seam-carving-sycl/kernels_wrapper.h
+++ b/seam-carving-sycl/kernels_wrapper.h
@@ -1,55 +1,56 @@
+#include <sycl/sycl.hpp>
 /* ################# wrappers ################### */
 
 void compute_costs(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<uchar4,1> &d_pixels, 
-    buffer<short, 1> &d_costs_left,
-    buffer<short, 1> &d_costs_up,
-    buffer<short, 1> &d_costs_right)
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<uchar4,1> &d_pixels,
+    sycl::buffer<short, 1> &d_costs_left,
+    sycl::buffer<short, 1> &d_costs_up,
+    sycl::buffer<short, 1> &d_costs_right)
 {
 #ifndef COMPUTE_COSTS_FULL
 
-  range<2> lws (COSTS_BLOCKSIZE_Y, COSTS_BLOCKSIZE_X);
-  range<2> gws (COSTS_BLOCKSIZE_Y * ((h-1)/(COSTS_BLOCKSIZE_Y-1) + 1), 
+    sycl::range<2> lws (COSTS_BLOCKSIZE_Y, COSTS_BLOCKSIZE_X);
+    sycl::range<2> gws (COSTS_BLOCKSIZE_Y * ((h-1)/(COSTS_BLOCKSIZE_Y-1) + 1),
                 COSTS_BLOCKSIZE_X * ((current_w-1)/(COSTS_BLOCKSIZE_X-2) + 1));
 
-  q.submit([&] (handler &cgh) {
-    auto p = d_pixels.get_access<sycl_read>(cgh);
-    auto cl = d_costs_left.get_access<sycl_write>(cgh);
-    auto cu = d_costs_up.get_access<sycl_write>(cgh);
-    auto cr = d_costs_right.get_access<sycl_write>(cgh);
-    accessor<pixel, 1, sycl_read_write, access::target::local> sm (COSTS_BLOCKSIZE_Y * COSTS_BLOCKSIZE_X, cgh);
-    cgh.parallel_for<class compute_costs>(nd_range<2>(gws, lws), [=] (nd_item<2> item) {
-      compute_costs_kernel(item, 
+  q.submit([&] (sycl::handler &cgh) {
+    auto p = d_pixels.get_access<sycl::access::mode::read>(cgh);
+    auto cl = d_costs_left.get_access<sycl::access::mode::write>(cgh);
+    auto cu = d_costs_up.get_access<sycl::access::mode::write>(cgh);
+    auto cr = d_costs_right.get_access<sycl::access::mode::write>(cgh);
+    sycl::local_accessor<pixel> sm (COSTS_BLOCKSIZE_Y * COSTS_BLOCKSIZE_X, cgh);
+    cgh.parallel_for<class compute_costs>(sycl::nd_range<2>(gws, lws), [=] (sycl::nd_item<2> item) {
+      compute_costs_kernel(item,
                            sm.get_pointer(),
-                           p.get_pointer(), 
+                           p.get_pointer(),
                            cl.get_pointer(),
                            cu.get_pointer(),
-                           cr.get_pointer(), 
+                           cr.get_pointer(),
                            w, h, current_w);
     });
   });
 
 #else
 
-  range<2> lws (COSTS_BLOCKSIZE_Y, COSTS_BLOCKSIZE_X);
-  range<2> gws (COSTS_BLOCKSIZE_Y * ((h-1)/COSTS_BLOCKSIZE_Y + 1), 
+  sycl::range<2> lws (COSTS_BLOCKSIZE_Y, COSTS_BLOCKSIZE_X);
+  sycl::range<2> gws (COSTS_BLOCKSIZE_Y * ((h-1)/COSTS_BLOCKSIZE_Y + 1),
                 COSTS_BLOCKSIZE_X * ((current_w-1)/COSTS_BLOCKSIZE_X + 1));
 
-  q.submit([&] (handler &cgh) {
-    auto p = d_pixels.get_access<sycl_read>(cgh);
-    auto cl = d_costs_left.get_access<sycl_write>(cgh);
-    auto cu = d_costs_up.get_access<sycl_write>(cgh);
-    auto cr = d_costs_right.get_access<sycl_write>(cgh);
-    accessor<pixel, 1, sycl_read_write, access::target::local> sm ((COSTS_BLOCKSIZE_Y+1) * (COSTS_BLOCKSIZE_X+2), cgh);
-    cgh.parallel_for<class compute_costs_full>(nd_range<2>(gws, lws), [=] (nd_item<2> item) {
-      compute_costs_full_kernel(item, 
+  q.submit([&] (sycl::handler &cgh) {
+    auto p = d_pixels.get_access<sycl::access::mode::read>(cgh);
+    auto cl = d_costs_left.get_access<sycl::access::mode::write>(cgh);
+    auto cu = d_costs_up.get_access<sycl::access::mode::write>(cgh);
+    auto cr = d_costs_right.get_access<sycl::access::mode::write>(cgh);
+    sycl::local_accessor<pixel> sm ((COSTS_BLOCKSIZE_Y+1) * (COSTS_BLOCKSIZE_X+2), cgh);
+    cgh.parallel_for<class compute_costs_full>(sycl::nd_range<2>(gws, lws), [=] (sycl::nd_item<2> item) {
+      compute_costs_full_kernel(item,
                                 sm.get_pointer(),
-                                p.get_pointer(), 
+                                p.get_pointer(),
                                 cl.get_pointer(),
                                 cu.get_pointer(),
-                                cr.get_pointer(), 
+                                cr.get_pointer(),
                                 w, h, current_w);
     });
   });
@@ -58,105 +59,105 @@ void compute_costs(
 }
 
 void compute_M(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<int, 1> &d_M, 
-    buffer<short, 1> &d_costs_left,
-    buffer<short, 1> &d_costs_up,
-    buffer<short, 1> &d_costs_right)
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<int, 1> &d_M,
+    sycl::buffer<short, 1> &d_costs_left,
+    sycl::buffer<short, 1> &d_costs_up,
+    sycl::buffer<short, 1> &d_costs_right)
 {
-#if !defined(COMPUTE_M_SINGLE) && !defined(COMPUTE_M_ITERATE)  
+#if !defined(COMPUTE_M_SINGLE) && !defined(COMPUTE_M_ITERATE)
 
   if(current_w <= 256){
-    range<1> gws (current_w);
-    range<1> lws (current_w);
+    sycl::range<1> gws (current_w);
+    sycl::range<1> lws (current_w);
     //compute_M_kernel_small<<<num_blocks, threads_per_block, 2*current_w*sizeof(int)>>>(d_costs_left, d_costs_up, d_costs_right, d_M, w, h, current_w);
-    q.submit([&] (handler &cgh) {
-      auto cl = d_costs_left.get_access<sycl_read>(cgh);
-      auto cu = d_costs_up.get_access<sycl_read>(cgh);
-      auto cr = d_costs_right.get_access<sycl_read>(cgh);
-      auto m = d_M.get_access<sycl_write>(cgh);
-      accessor<int, 1, sycl_read_write, access::target::local> sm (2*current_w, cgh);
-      cgh.parallel_for<class compute_M_small>(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-        compute_M_kernel_small(item, 
+    q.submit([&] (sycl::handler &cgh) {
+      auto cl = d_costs_left.get_access<sycl::access::mode::read>(cgh);
+      auto cu = d_costs_up.get_access<sycl::access::mode::read>(cgh);
+      auto cr = d_costs_right.get_access<sycl::access::mode::read>(cgh);
+      auto m = d_M.get_access<sycl::access::mode::write>(cgh);
+      sycl::local_accessor<int> sm (2*current_w, cgh);
+      cgh.parallel_for<class compute_M_small>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+        compute_M_kernel_small(item,
                                sm.get_pointer(),
                                cl.get_pointer(),
                                cu.get_pointer(),
-                               cr.get_pointer(), 
-                               m.get_pointer(), 
+                               cr.get_pointer(),
+                               m.get_pointer(),
                                w, h, current_w);
       });
     });
   }
   else{
-    range<1> lws (COMPUTE_M_BLOCKSIZE_X);
-    range<1> gws (COMPUTE_M_BLOCKSIZE_X * ((current_w-1)/COMPUTE_M_BLOCKSIZE_X + 1));
-    range<1> gws2 (COMPUTE_M_BLOCKSIZE_X * ((current_w-COMPUTE_M_BLOCKSIZE_X-1)/COMPUTE_M_BLOCKSIZE_X + 1)); 
+    sycl::range<1> lws (COMPUTE_M_BLOCKSIZE_X);
+    sycl::range<1> gws (COMPUTE_M_BLOCKSIZE_X * ((current_w-1)/COMPUTE_M_BLOCKSIZE_X + 1));
+    sycl::range<1> gws2 (COMPUTE_M_BLOCKSIZE_X * ((current_w-COMPUTE_M_BLOCKSIZE_X-1)/COMPUTE_M_BLOCKSIZE_X + 1));
 
     int num_iterations = (h-1)/(COMPUTE_M_BLOCKSIZE_X/2 - 1) + 1;
 
     int base_row = 0;
     for(int i = 0; i < num_iterations; i++){
       //compute_M_kernel_step1<<<num_blocks, threads_per_block>>>(d_costs_left, d_costs_up, d_costs_right, d_M, w, h, current_w, base_row);
-      q.submit([&] (handler &cgh) {
-        auto cl = d_costs_left.get_access<sycl_write>(cgh);
-        auto cu = d_costs_up.get_access<sycl_write>(cgh);
-        auto cr = d_costs_right.get_access<sycl_write>(cgh);
-        auto m = d_M.get_access<sycl_read>(cgh);
-        accessor<int, 1, sycl_read_write, access::target::local> sm (2*COMPUTE_M_BLOCKSIZE_X, cgh);
-        cgh.parallel_for<class compute_M_step1>(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-          compute_M_kernel_step1(item, 
+      q.submit([&] (sycl::handler &cgh) {
+        auto cl = d_costs_left.get_access<sycl::access::mode::write>(cgh);
+        auto cu = d_costs_up.get_access<sycl::access::mode::write>(cgh);
+        auto cr = d_costs_right.get_access<sycl::access::mode::write>(cgh);
+        auto m = d_M.get_access<sycl::access::mode::read>(cgh);
+        sycl::local_accessor<int> sm (2*COMPUTE_M_BLOCKSIZE_X, cgh);
+        cgh.parallel_for<class compute_M_step1>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+          compute_M_kernel_step1(item,
                                  sm.get_pointer(),
                                  cl.get_pointer(),
                                  cu.get_pointer(),
-                                 cr.get_pointer(), 
-                                 m.get_pointer(), 
+                                 cr.get_pointer(),
+                                 m.get_pointer(),
                                  w, h, current_w, base_row);
         });
       });
 
       //compute_M_kernel_step2<<<num_blocks2, threads_per_block>>>(d_costs_left, d_costs_up, d_costs_right, d_M, w, h, current_w, base_row);
-      q.submit([&] (handler &cgh) {
-        auto cl = d_costs_left.get_access<sycl_read>(cgh);
-        auto cu = d_costs_up.get_access<sycl_read>(cgh);
-        auto cr = d_costs_right.get_access<sycl_read>(cgh);
-        auto m = d_M.get_access<sycl_write>(cgh);
-        cgh.parallel_for<class compute_M_step2>(nd_range<1>(gws2, lws), [=] (nd_item<1> item) {
-          compute_M_kernel_step2(item, 
+      q.submit([&] (sycl::handler &cgh) {
+        auto cl = d_costs_left.get_access<sycl::access::mode::read>(cgh);
+        auto cu = d_costs_up.get_access<sycl::access::mode::read>(cgh);
+        auto cr = d_costs_right.get_access<sycl::access::mode::read>(cgh);
+        auto m = d_M.get_access<sycl::access::mode::write>(cgh);
+        cgh.parallel_for<class compute_M_step2>(sycl::nd_range<1>(gws2, lws), [=] (sycl::nd_item<1> item) {
+          compute_M_kernel_step2(item,
                                  cl.get_pointer(),
                                  cu.get_pointer(),
-                                 cr.get_pointer(), 
-                                 m.get_pointer(), 
+                                 cr.get_pointer(),
+                                 m.get_pointer(),
                                  w, h, current_w, base_row);
         });
       });
 
-      base_row = base_row + (COMPUTE_M_BLOCKSIZE_X/2) - 1;    
+      base_row = base_row + (COMPUTE_M_BLOCKSIZE_X/2) - 1;
     }
   }
 
 #endif
-#ifdef COMPUTE_M_SINGLE    
+#ifdef COMPUTE_M_SINGLE
 
   int block_size = std::min(256, next_pow2(current_w));
-  range<1> lws (block_size);
-  range<1> gws (block_size);
+  sycl::range<1> lws (block_size);
+  sycl::range<1> gws (block_size);
 
   int num_el = (current_w-1)/block_size + 1;
   //compute_M_kernel_single<<<num_blocks, threads_per_block, 2*current_w*sizeof(int)>>>(d_costs_left, d_costs_up, d_costs_right, d_M, w, h, current_w, num_el);
-  q.submit([&] (handler &cgh) {
-    auto cl = d_costs_left.get_access<sycl_read>(cgh);
-    auto cu = d_costs_up.get_access<sycl_read>(cgh);
-    auto cr = d_costs_right.get_access<sycl_read>(cgh);
-    auto m = d_M.get_access<sycl_write>(cgh);
-    accessor<int, 1, sycl_read_write, access::target::local> sm (2*current_w, cgh);
-    cgh.parallel_for<class compute_M_single>(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-      compute_M_kernel_single(item, 
+  q.submit([&] (sycl::handler &cgh) {
+    auto cl = d_costs_left.get_access<sycl::access::mode::read>(cgh);
+    auto cu = d_costs_up.get_access<sycl::access::mode::read>(cgh);
+    auto cr = d_costs_right.get_access<sycl::access::mode::read>(cgh);
+    auto m = d_M.get_access<sycl::access::mode::write>(cgh);
+    sycl::local_accessor<int> sm (2*current_w, cgh);
+    cgh.parallel_for<class compute_M_single>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+      compute_M_kernel_single(item,
                               sm.get_pointer(),
                               cl.get_pointer(),
                               cu.get_pointer(),
-                              cr.get_pointer(), 
-                              m.get_pointer(), 
+                              cr.get_pointer(),
+                              m.get_pointer(),
                               w, h, current_w, num_el);
       });
     });
@@ -164,38 +165,38 @@ void compute_M(
 #else
 #ifdef COMPUTE_M_ITERATE
 
-  range<1> gws (COMPUTE_M_BLOCKSIZE_X * ((current_w-1)/COMPUTE_M_BLOCKSIZE_X + 1));
-  range<1> lws (COMPUTE_M_BLOCKSIZE_X);
+  sycl::range<1> gws (COMPUTE_M_BLOCKSIZE_X * ((current_w-1)/COMPUTE_M_BLOCKSIZE_X + 1));
+  sycl::range<1> lws (COMPUTE_M_BLOCKSIZE_X);
 
   //compute_M_kernel_iterate0<<<num_blocks, threads_per_block>>>(d_costs_left, d_costs_up, d_costs_right, d_M, w, current_w);
-  q.submit([&] (handler &cgh) {
-    auto cl = d_costs_left.get_access<sycl_read>(cgh);
-    auto cu = d_costs_up.get_access<sycl_read>(cgh);
-    auto cr = d_costs_right.get_access<sycl_read>(cgh);
-    auto m = d_M.get_access<sycl_write>(cgh);
-    cgh.parallel_for<class compute_M_iter0>(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-      compute_M_kernel_iterate0(item, 
+  q.submit([&] (sycl::handler &cgh) {
+    auto cl = d_costs_left.get_access<sycl::access::mode::read>(cgh);
+    auto cu = d_costs_up.get_access<sycl::access::mode::read>(cgh);
+    auto cr = d_costs_right.get_access<sycl::access::mode::read>(cgh);
+    auto m = d_M.get_access<sycl::access::mode::write>(cgh);
+    cgh.parallel_for<class compute_M_iter0>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+      compute_M_kernel_iterate0(item,
                                 cl.get_pointer(),
                                 cu.get_pointer(),
-                                cr.get_pointer(), 
-                                m.get_pointer(), 
+                                cr.get_pointer(),
+                                m.get_pointer(),
                                 w, current_w);
       });
     });
 
   for(int row = 1; row < h; row++){
   //  compute_M_kernel_iterate1<<<num_blocks, threads_per_block>>>(d_costs_left, d_costs_up, d_costs_right, d_M, w, current_w, row);
-    q.submit([&] (handler &cgh) {
-      auto cl = d_costs_left.get_access<sycl_read>(cgh);
-      auto cu = d_costs_up.get_access<sycl_read>(cgh);
-      auto cr = d_costs_right.get_access<sycl_read>(cgh);
-      auto m = d_M.get_access<sycl_read_write>(cgh);
-      cgh.parallel_for<class compute_M_iter1>(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-        compute_M_kernel_iterate1(item, 
+    q.submit([&] (sycl::handler &cgh) {
+      auto cl = d_costs_left.get_access<sycl::access::mode::read>(cgh);
+      auto cu = d_costs_up.get_access<sycl::access::mode::read>(cgh);
+      auto cr = d_costs_right.get_access<sycl::access::mode::read>(cgh);
+      auto m = d_M.get_access<sycl::access::mode::read_write>(cgh);
+      cgh.parallel_for<class compute_M_iter1>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+        compute_M_kernel_iterate1(item,
                                   cl.get_pointer(),
                                   cu.get_pointer(),
-                                  cr.get_pointer(), 
-                                  m.get_pointer(), 
+                                  cr.get_pointer(),
+                                  m.get_pointer(),
                                   w, current_w, row);
         });
       });
@@ -206,35 +207,35 @@ void compute_M(
 }
 
 void find_min_index(
-    queue &q,
+    sycl::queue &q,
     int current_w,
-    buffer<int, 1> &d_indices_ref,
-    buffer<int, 1> &d_indices,
-    buffer<int, 1> &reduce_row)
+    sycl::buffer<int, 1> &d_indices_ref,
+    sycl::buffer<int, 1> &d_indices,
+    sycl::buffer<int, 1> &reduce_row)
 {
   //set the reference index array
   //cudaMemcpy(d_indices, d_indices_ref, current_w*sizeof(int), cudaMemcpyDeviceToDevice);
-  q.submit([&] (handler &cgh) {
-    auto src = d_indices_ref.get_access<sycl_read>(cgh);
-    auto dst = d_indices.get_access<sycl_write>(cgh);
+  q.submit([&] (sycl::handler &cgh) {
+    auto src = d_indices_ref.get_access<sycl::access::mode::read>(cgh);
+    auto dst = d_indices.get_access<sycl::access::mode::write>(cgh);
     cgh.copy(src, dst);
   });
 
-  range<1> lws (REDUCE_BLOCKSIZE_X);
-  range<1> gws (1);
+  sycl::range<1> lws (REDUCE_BLOCKSIZE_X);
+  sycl::range<1> gws (1);
 
   int reduce_num_elements = current_w;
   do{
     int num_blocks_x = (reduce_num_elements-1)/(REDUCE_BLOCKSIZE_X*REDUCE_ELEMENTS_PER_THREAD) + 1;
-    gws[0] = REDUCE_BLOCKSIZE_X * num_blocks_x; 
-    // min_reduce<<<num_blocks, threads_per_block>>>(reduce_row, d_indices, reduce_num_elements); 
-    q.submit([&] (handler &cgh) {
-      auto r = reduce_row.get_access<sycl_read>(cgh);
-      auto i = d_indices.get_access<sycl_write>(cgh);
-      accessor<int, 1, sycl_read_write, access::target::local> sm_val (REDUCE_BLOCKSIZE_X, cgh);
-      accessor<int, 1, sycl_read_write, access::target::local> sm_ix (REDUCE_BLOCKSIZE_X, cgh);
-      cgh.parallel_for<class reduce>(nd_range<1>(gws, lws), [=] (nd_item<1> item) {
-        min_reduce( item, 
+    gws[0] = REDUCE_BLOCKSIZE_X * num_blocks_x;
+    // min_reduce<<<num_blocks, threads_per_block>>>(reduce_row, d_indices, reduce_num_elements);
+    q.submit([&] (sycl::handler &cgh) {
+      auto r = reduce_row.get_access<sycl::access::mode::read>(cgh);
+      auto i = d_indices.get_access<sycl::access::mode::write>(cgh);
+      sycl::local_accessor<int> sm_val (REDUCE_BLOCKSIZE_X, cgh);
+      sycl::local_accessor<int> sm_ix (REDUCE_BLOCKSIZE_X, cgh);
+      cgh.parallel_for<class reduce>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {
+        min_reduce( item,
                     sm_val.get_pointer(),
                     sm_ix.get_pointer(),
                     r.get_pointer(),
@@ -243,21 +244,21 @@ void find_min_index(
       });
     });
     reduce_num_elements = num_blocks_x;
-  }while(reduce_num_elements > 1);    
+  }while(reduce_num_elements > 1);
 }
 
 void find_seam(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<int, 1> &d_M,
-    buffer<int, 1> &d_indices,
-    buffer<int, 1> &d_seam )
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<int, 1> &d_M,
+    sycl::buffer<int, 1> &d_indices,
+    sycl::buffer<int, 1> &d_seam )
 {
   //find_seam_kernel<<<1, 1>>>(d_M, d_indices, d_seam, w, h, current_w);
-  q.submit([&] (handler &cgh) {
-    auto m = d_M.get_access<sycl_read>(cgh);
-    auto i = d_indices.get_access<sycl_read>(cgh);
-    auto s = d_seam.get_access<sycl_write>(cgh);
+  q.submit([&] (sycl::handler &cgh) {
+    auto m = d_M.get_access<sycl::access::mode::read>(cgh);
+    auto i = d_indices.get_access<sycl::access::mode::read>(cgh);
+    auto s = d_seam.get_access<sycl::access::mode::write>(cgh);
     cgh.single_task<class find_seam>( [=] () {
       find_seam_kernel(
         m.get_pointer(), i.get_pointer(), s.get_pointer(), w, h, current_w);
@@ -266,25 +267,25 @@ void find_seam(
 }
 
 void remove_seam(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<int, 1> &d_M,
-    buffer<uchar4, 1> &d_pixels,
-    buffer<uchar4, 1> &d_pixels_swap,
-    buffer<int, 1> &d_seam )
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<int, 1> &d_M,
+    sycl::buffer<uchar4, 1> &d_pixels,
+    sycl::buffer<uchar4, 1> &d_pixels_swap,
+    sycl::buffer<int, 1> &d_seam )
 {
   int num_blocks_x = (current_w-1)/REMOVE_BLOCKSIZE_X + 1;
-  int num_blocks_y = (h-1)/REMOVE_BLOCKSIZE_Y + 1;    
-  range<2> lws (REMOVE_BLOCKSIZE_Y, REMOVE_BLOCKSIZE_X);
-  range<2> gws (REMOVE_BLOCKSIZE_Y * num_blocks_y,
+  int num_blocks_y = (h-1)/REMOVE_BLOCKSIZE_Y + 1;
+  sycl::range<2> lws (REMOVE_BLOCKSIZE_Y, REMOVE_BLOCKSIZE_X);
+  sycl::range<2> gws (REMOVE_BLOCKSIZE_Y * num_blocks_y,
                 REMOVE_BLOCKSIZE_X * num_blocks_x);
 
   //remove_seam_kernel<<<num_blocks, threads_per_block>>>(d_pixels, d_pixels_swap, d_seam, w, h, current_w);
-  q.submit([&] (handler &cgh) {
-    auto p = d_pixels.get_access<sycl_read>(cgh);
-    auto ps = d_pixels_swap.get_access<sycl_write>(cgh);
-    auto s = d_seam.get_access<sycl_read>(cgh);
-    cgh.parallel_for<class update_seam>(nd_range<2>(gws, lws), [=] (nd_item<2> item) {
+  q.submit([&] (sycl::handler &cgh) {
+    auto p = d_pixels.get_access<sycl::access::mode::read>(cgh);
+    auto ps = d_pixels_swap.get_access<sycl::access::mode::write>(cgh);
+    auto s = d_seam.get_access<sycl::access::mode::read>(cgh);
+    cgh.parallel_for<class update_seam>(sycl::nd_range<2>(gws, lws), [=] (sycl::nd_item<2> item) {
       remove_seam_kernel(item,
         p.get_pointer(),
         ps.get_pointer(),
@@ -295,34 +296,34 @@ void remove_seam(
 }
 
 void update_costs(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<int, 1> &d_M,
-    buffer<uchar4, 1> &d_pixels,
-    buffer<short, 1> &d_costs_left,
-    buffer<short, 1> &d_costs_up,
-    buffer<short, 1> &d_costs_right,
-    buffer<short, 1> &d_costs_swap_left,
-    buffer<short, 1> &d_costs_swap_up,
-    buffer<short, 1> &d_costs_swap_right,
-    buffer<int, 1> &d_seam )
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<int, 1> &d_M,
+    sycl::buffer<uchar4, 1> &d_pixels,
+    sycl::buffer<short, 1> &d_costs_left,
+    sycl::buffer<short, 1> &d_costs_up,
+    sycl::buffer<short, 1> &d_costs_right,
+    sycl::buffer<short, 1> &d_costs_swap_left,
+    sycl::buffer<short, 1> &d_costs_swap_up,
+    sycl::buffer<short, 1> &d_costs_swap_right,
+    sycl::buffer<int, 1> &d_seam )
 {
   int num_blocks_x = (current_w-1)/UPDATE_BLOCKSIZE_X + 1;
-  int num_blocks_y = (h-1)/UPDATE_BLOCKSIZE_Y + 1;    
-  range<2> lws (UPDATE_BLOCKSIZE_Y, UPDATE_BLOCKSIZE_X);
-  range<2> gws (UPDATE_BLOCKSIZE_Y * num_blocks_y,
+  int num_blocks_y = (h-1)/UPDATE_BLOCKSIZE_Y + 1;
+  sycl::range<2> lws (UPDATE_BLOCKSIZE_Y, UPDATE_BLOCKSIZE_X);
+  sycl::range<2> gws (UPDATE_BLOCKSIZE_Y * num_blocks_y,
                 UPDATE_BLOCKSIZE_X * num_blocks_x);
-                
-  q.submit([&] (handler &cgh) {
-    auto p = d_pixels.get_access<sycl_read>(cgh);
-    auto cl = d_costs_left.get_access<sycl_read>(cgh);
-    auto cu = d_costs_up.get_access<sycl_read>(cgh);
-    auto cr = d_costs_right.get_access<sycl_read>(cgh);
-    auto cls = d_costs_swap_left.get_access<sycl_write>(cgh);
-    auto cus = d_costs_swap_up.get_access<sycl_write>(cgh);
-    auto crs = d_costs_swap_right.get_access<sycl_write>(cgh);
-    auto s = d_seam.get_access<sycl_read>(cgh);
-    cgh.parallel_for<class update_costs>(nd_range<2>(gws, lws), [=] (nd_item<2> item) {
+
+  q.submit([&] (sycl::handler &cgh) {
+    auto p = d_pixels.get_access<sycl::access::mode::read>(cgh);
+    auto cl = d_costs_left.get_access<sycl::access::mode::read>(cgh);
+    auto cu = d_costs_up.get_access<sycl::access::mode::read>(cgh);
+    auto cr = d_costs_right.get_access<sycl::access::mode::read>(cgh);
+    auto cls = d_costs_swap_left.get_access<sycl::access::mode::write>(cgh);
+    auto cus = d_costs_swap_up.get_access<sycl::access::mode::write>(cgh);
+    auto crs = d_costs_swap_right.get_access<sycl::access::mode::write>(cgh);
+    auto s = d_seam.get_access<sycl::access::mode::read>(cgh);
+    cgh.parallel_for<class update_costs>(sycl::nd_range<2>(gws, lws), [=] (sycl::nd_item<2> item) {
       update_costs_kernel (item,
         p.get_pointer(),
         cl.get_pointer(),
@@ -331,37 +332,37 @@ void update_costs(
         cls.get_pointer(),
         cus.get_pointer(),
         crs.get_pointer(),
-        s.get_pointer(), 
+        s.get_pointer(),
         w, h, current_w);
     });
   });
 }
 
 void approx_setup(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<uchar4, 1> &d_pixels,
-    buffer<int, 1> &d_index_map,
-    buffer<int, 1> &d_offset_map,
-    buffer<int, 1> &d_M )
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<uchar4, 1> &d_pixels,
+    sycl::buffer<int, 1> &d_index_map,
+    sycl::buffer<int, 1> &d_offset_map,
+    sycl::buffer<int, 1> &d_M )
 {
   int num_blocks_x = (current_w-1)/(APPROX_SETUP_BLOCKSIZE_X-4) + 1;
-  int num_blocks_y = (h-2)/(APPROX_SETUP_BLOCKSIZE_Y-1) + 1;    
-  range<2> lws (APPROX_SETUP_BLOCKSIZE_Y, APPROX_SETUP_BLOCKSIZE_X);
-  range<2> gws (num_blocks_y * APPROX_SETUP_BLOCKSIZE_Y,
+  int num_blocks_y = (h-2)/(APPROX_SETUP_BLOCKSIZE_Y-1) + 1;
+  sycl::range<2> lws (APPROX_SETUP_BLOCKSIZE_Y, APPROX_SETUP_BLOCKSIZE_X);
+  sycl::range<2> gws (num_blocks_y * APPROX_SETUP_BLOCKSIZE_Y,
                 num_blocks_x * APPROX_SETUP_BLOCKSIZE_X);
- 
-  q.submit([&] (handler &cgh) {
-    auto p = d_pixels.get_access<sycl_read>(cgh);
-    auto i = d_index_map.get_access<sycl_write>(cgh);
-    auto o = d_offset_map.get_access<sycl_write>(cgh);
-    auto m = d_M.get_access<sycl_write>(cgh);
-    accessor<pixel, 1, sycl_read_write, access::target::local> p_sm (APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
-    accessor<short, 1, sycl_read_write, access::target::local> l_sm (APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
-    accessor<short, 1, sycl_read_write, access::target::local> u_sm (APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
-    accessor<short, 1, sycl_read_write, access::target::local> r_sm(APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
 
-    cgh.parallel_for<class approx_setup>(nd_range<2>(gws, lws), [=] (nd_item<2> item) {
+  q.submit([&] (sycl::handler &cgh) {
+    auto p = d_pixels.get_access<sycl::access::mode::read>(cgh);
+    auto i = d_index_map.get_access<sycl::access::mode::write>(cgh);
+    auto o = d_offset_map.get_access<sycl::access::mode::write>(cgh);
+    auto m = d_M.get_access<sycl::access::mode::write>(cgh);
+    sycl::local_accessor<pixel> p_sm (APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
+    sycl::local_accessor<short> l_sm (APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
+    sycl::local_accessor<short> u_sm (APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
+    sycl::local_accessor<short> r_sm(APPROX_SETUP_BLOCKSIZE_Y*APPROX_SETUP_BLOCKSIZE_X, cgh);
+
+    cgh.parallel_for<class approx_setup>(sycl::nd_range<2>(gws, lws), [=] (sycl::nd_item<2> item) {
 
       approx_setup_kernel(item,
         p_sm.get_pointer(),
@@ -378,47 +379,47 @@ void approx_setup(
 }
 
 void approx_M(
-    queue &q,
-    int current_w, int w, int h, 
-    buffer<int, 1> &d_offset_map,
-    buffer<int, 1> &d_M )
+    sycl::queue &q,
+    int current_w, int w, int h,
+    sycl::buffer<int, 1> &d_offset_map,
+    sycl::buffer<int, 1> &d_M )
 {
   int num_blocks_x = (current_w-1)/APPROX_M_BLOCKSIZE_X + 1;
   int num_blocks_y = h/2;
-  range<2> lws (1, APPROX_M_BLOCKSIZE_X);
-  range<2> gws (h/2, APPROX_M_BLOCKSIZE_X * num_blocks_x);
+  sycl::range<2> lws (1, APPROX_M_BLOCKSIZE_X);
+  sycl::range<2> gws (h/2, APPROX_M_BLOCKSIZE_X * num_blocks_x);
 
   int step = 1;
   while(num_blocks_y > 0){
    // approx_M_kernel<<<num_blocks, threads_per_block>>>(d_offset_map, d_M, w, h, current_w, step);
-    q.submit([&] (handler &cgh) {
-      auto o = d_offset_map.get_access<sycl_read_write>(cgh);
-      auto m = d_M.get_access<sycl_read_write>(cgh);
-      cgh.parallel_for<class approx_M>(nd_range<2>(gws, lws), [=] (nd_item<2> item) {
+    q.submit([&] (sycl::handler &cgh) {
+      auto o = d_offset_map.get_access<sycl::access::mode::read_write>(cgh);
+      auto m = d_M.get_access<sycl::access::mode::read_write>(cgh);
+      cgh.parallel_for<class approx_M>(sycl::nd_range<2>(gws, lws), [=] (sycl::nd_item<2> item) {
         approx_M_kernel(item,
-          o.get_pointer(), 
+          o.get_pointer(),
           m.get_pointer(),
           w, h, current_w, step);
       });
     });
-    
+
     num_blocks_y = num_blocks_y/2;
     step = step*2;
   }
 }
 
 void approx_seam(
-    queue &q,
-    int w, int h, 
-    buffer<int, 1> &d_index_map,
-    buffer<int, 1> &d_indices,
-    buffer<int, 1> &d_seam )
+    sycl::queue &q,
+    int w, int h,
+    sycl::buffer<int, 1> &d_index_map,
+    sycl::buffer<int, 1> &d_indices,
+    sycl::buffer<int, 1> &d_seam )
 {
   //approx_seam_kernel<<<1, 1>>>(d_index_map, d_indices, d_seam, w, h);
-  q.submit([&] (handler &cgh) {
-    auto m = d_index_map.get_access<sycl_read>(cgh);
-    auto i = d_indices.get_access<sycl_read>(cgh);
-    auto s = d_seam.get_access<sycl_write>(cgh);
+  q.submit([&] (sycl::handler &cgh) {
+    auto m = d_index_map.get_access<sycl::access::mode::read>(cgh);
+    auto i = d_indices.get_access<sycl::access::mode::read>(cgh);
+    auto s = d_seam.get_access<sycl::access::mode::write>(cgh);
     cgh.single_task<class approx_seam>( [=] () {
       approx_seam_kernel(
         m.get_pointer(), i.get_pointer(), s.get_pointer(), w, h);

--- a/seam-carving-sycl/utils.h
+++ b/seam-carving-sycl/utils.h
@@ -1,3 +1,7 @@
+#include <sycl/sycl.hpp>
+
+using uchar4 = sycl::vec<unsigned char, 4>;
+
 typedef enum {
     SEAM_CARVER_STANDARD_MODE,
     SEAM_CARVER_UPDATE_MODE,
@@ -20,8 +24,8 @@ uchar4 *build_pixels(const unsigned char *imgv, int w, int h){
     for(int j = 0; j < w; j++){
       pix.x() = imgv[i*3*w + 3*j];
       pix.y() = imgv[i*3*w + 3*j + 1];
-      pix.z() = imgv[i*3*w + 3*j + 2]; 
-      pixels[i*w + j] = pix;            
+      pix.z() = imgv[i*3*w + 3*j + 2];
+      pixels[i*w + j] = pix;
     }
   }
   return pixels;
@@ -30,7 +34,7 @@ uchar4 *build_pixels(const unsigned char *imgv, int w, int h){
 unsigned char *flatten_pixels(uchar4 *pixels, int w, int h, int new_w){
   unsigned char *flattened = (unsigned char*)malloc(3*new_w*h*sizeof(unsigned char));
   for(int i = 0; i < h; i++){
-    for(int j = 0; j < new_w; j++){ 
+    for(int j = 0; j < new_w; j++){
       uchar4 pix = pixels[i*w + j];
       flattened[3*i*new_w + 3*j] = pix.x();
       flattened[3*i*new_w + 3*j + 1] = pix.y();

--- a/testSNAP-sycl/main.cpp
+++ b/testSNAP-sycl/main.cpp
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
-#include "common.h"
+#include <sycl/sycl.hpp>
 #include "snap.h"
 #include "utils.cpp"
 
@@ -48,14 +48,14 @@ int nsteps = 1; // num of force evaluations
 /// \returns The value at the \p addr before the call.
 inline double atomicAdd( double *addr, double operand )
 {
-  atomic<long, access::address_space::global_space> obj(
-    (multi_ptr<long, access::address_space::global_space>(reinterpret_cast<long *>(addr))));
+  sycl::atomic_ref<long, sycl::memory_order::relaxed, sycl::memory_scope::device, sycl::access::address_space::global_space> obj(
+    (*reinterpret_cast<long *>(addr)));
 
   long old_value;
   double old_double_value;
 
   do {
-    old_value = obj.load(memory_order::relaxed);
+    old_value = obj.load(sycl::memory_order::relaxed);
     old_double_value = *reinterpret_cast<const double *>(&old_value);
     const double new_double_value = old_double_value + operand;
     const long new_value = *reinterpret_cast<const long *>(&new_double_value);
@@ -74,8 +74,8 @@ int main(int argc, char* argv[])
   const int switch_flag = 1;     // SNAP parameter
 
   // record timings of individual routines
-  double elapsed_ui = 0.0, 
-         elapsed_yi = 0.0, 
+  double elapsed_ui = 0.0,
+         elapsed_yi = 0.0,
          elapsed_duidrj = 0.0,
          elapsed_deidrj = 0.0;
 
@@ -88,8 +88,8 @@ int main(int argc, char* argv[])
   const double rcutfac = refdata.rcutfac;
 
   const double wself = 1.0;
-  const int num_atoms = nlocal; 
-  const int num_nbor = ninside; 
+  const int num_atoms = nlocal;
+  const int num_nbor = ninside;
 
   //coeffi = memory->grow(coeffi, ncoeff + 1, "coeffi");
   double* coeffi = (double*) malloc (sizeof(double) * (ncoeff+1));
@@ -305,9 +305,9 @@ int main(int argc, char* argv[])
   const int jdimpq = twojmax + 2;
   double* rootpqarray = (double*) malloc(sizeof(double) * jdimpq * jdimpq);
   double* cglist = (double*) malloc (sizeof(double) * idxcg_max);
-  double* dedr = (double*) malloc (sizeof(double) * num_atoms * num_nbor * 3); 
+  double* dedr = (double*) malloc (sizeof(double) * num_atoms * num_nbor * 3);
 
-  COMPLEX* ulist = (COMPLEX*) malloc (sizeof(COMPLEX) * num_atoms * num_nbor * idxu_max); 
+  COMPLEX* ulist = (COMPLEX*) malloc (sizeof(COMPLEX) * num_atoms * num_nbor * idxu_max);
   COMPLEX* ylist = (COMPLEX*) malloc (sizeof(COMPLEX) * num_atoms * idxdu_max);
   COMPLEX* ulisttot = (COMPLEX*) malloc (sizeof(COMPLEX) * num_atoms * idxu_max);
   COMPLEX* dulist = (COMPLEX*) malloc (sizeof(COMPLEX) * num_atoms * num_nbor * 3 * idxdu_max);
@@ -375,35 +375,34 @@ int main(int argc, char* argv[])
   double sumsqferr = 0.0;
 
 #ifdef USE_GPU
-  gpu_selector dev_sel;
+  sycl::queue q(sycl::gpu_selector_v);
 #else
-  cpu_selector dev_sel;
+  sycl::queue q(sycl::cpu_selector_v);
 #endif
-  queue q(dev_sel);
 
-  buffer<int, 1> d_idxu_block(idxu_block, jdim);
-  buffer<int, 1> d_ulist_parity(ulist_parity, idxu_max);
-  buffer<double, 1> d_rootpqarray(rootpqarray, jdimpq * jdimpq);
-  buffer<int, 1> d_idxz(idxz, idxz_max * 9);
-  buffer<double, 1> d_idxzbeta(idxzbeta, idxz_max);
-  buffer<int, 1> d_idxcg_block(idxcg_block, jdim * jdim * jdim);
-  buffer<int, 1> d_idxdu_block(idxdu_block, jdim);
-  buffer<double, 1> d_cglist(cglist, idxcg_max);
+  sycl::buffer<int, 1> d_idxu_block(idxu_block, jdim);
+  sycl::buffer<int, 1> d_ulist_parity(ulist_parity, idxu_max);
+  sycl::buffer<double, 1> d_rootpqarray(rootpqarray, jdimpq * jdimpq);
+  sycl::buffer<int, 1> d_idxz(idxz, idxz_max * 9);
+  sycl::buffer<double, 1> d_idxzbeta(idxzbeta, idxz_max);
+  sycl::buffer<int, 1> d_idxcg_block(idxcg_block, jdim * jdim * jdim);
+  sycl::buffer<int, 1> d_idxdu_block(idxdu_block, jdim);
+  sycl::buffer<double, 1> d_cglist(cglist, idxcg_max);
 
-  buffer<COMPLEX, 1> d_dulist(dulist, num_atoms * num_nbor * 3 * idxdu_max);
-  buffer<COMPLEX, 1> d_ulist(ulist, num_atoms * num_nbor * idxu_max);
-  buffer<double, 1> d_dedr(dedr, num_atoms * num_nbor * 3);
+  sycl::buffer<COMPLEX, 1> d_dulist(dulist, num_atoms * num_nbor * 3 * idxdu_max);
+  sycl::buffer<COMPLEX, 1> d_ulist(ulist, num_atoms * num_nbor * idxu_max);
+  sycl::buffer<double, 1> d_dedr(dedr, num_atoms * num_nbor * 3);
 
   d_ulist.set_final_data(nullptr);
   d_dulist.set_final_data(nullptr);
   d_dedr.set_final_data(nullptr);
 
-  buffer<COMPLEX, 1> d_ulisttot(num_atoms * idxu_max);
-  buffer<COMPLEX, 1> d_ylist(num_atoms * idxdu_max);
+  sycl::buffer<COMPLEX, 1> d_ulisttot(num_atoms * idxu_max);
+  sycl::buffer<COMPLEX, 1> d_ylist(num_atoms * idxdu_max);
 
-  buffer<double, 1> d_rij(num_atoms*num_nbor*3);
-  buffer<double, 1> d_rcutij(num_atoms*num_nbor);
-  buffer<double, 1> d_wj(num_atoms*num_nbor);
+  sycl::buffer<double, 1> d_rij(num_atoms*num_nbor*3);
+  sycl::buffer<double, 1> d_rcutij(num_atoms*num_nbor);
+  sycl::buffer<double, 1> d_wj(num_atoms*num_nbor);
 
   // loop over steps
 
@@ -429,18 +428,18 @@ int main(int argc, char* argv[])
       }
     }
 
-    q.submit([&] (handler &cgh) {
-      auto acc = d_rij.get_access<sycl_discard_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto acc = d_rij.get_access<sycl::access::mode::discard_write>(cgh);
       cgh.copy(rij, acc);
     });
 
-    q.submit([&] (handler &cgh) {
-      auto acc = d_rcutij.get_access<sycl_discard_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto acc = d_rcutij.get_access<sycl::access::mode::discard_write>(cgh);
       cgh.copy(rcutij, acc);
     });
 
-    q.submit([&] (handler &cgh) {
-      auto acc = d_wj.get_access<sycl_discard_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto acc = d_wj.get_access<sycl::access::mode::discard_write>(cgh);
       cgh.copy(wj, acc);
     });
 
@@ -453,24 +452,24 @@ int main(int argc, char* argv[])
     //   compute r0 = (x,y,z,z0)
     //   utot(j,ma,mb) += u(r0;j,ma,mb) for all j,ma,mb
 
-    range<1> gws_k1 ((num_atoms*idxu_max+255)/256*256);
-    range<1> lws_k1 (256);
-    q.submit([&] (handler &cgh) {
-      auto acc = d_ulisttot.get_access<sycl_write>(cgh);
-      cgh.parallel_for<class reset_ulisttot>(nd_range<1>(gws_k1, lws_k1), [=] (nd_item<1> item) {
+    sycl::range<1> gws_k1 ((num_atoms*idxu_max+255)/256*256);
+    sycl::range<1> lws_k1 (256);
+    q.submit([&] (sycl::handler &cgh) {
+      auto acc = d_ulisttot.get_access<sycl::access::mode::write>(cgh);
+      cgh.parallel_for<class reset_ulisttot>(sycl::nd_range<1>(gws_k1, lws_k1), [=] (sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
         if (i < num_atoms*idxu_max) acc[i] = {0.0, 0.0};
       });
     });
 
-    range<1> gws_k2 ((num_atoms+255)/256*256);
-    range<1> lws_k2 (256);
-    q.submit([&] (handler &cgh) {
-      auto ulisttot = d_ulisttot.get_access<sycl_write>(cgh);
-      auto idxu_block = d_idxu_block.get_access<sycl_read>(cgh);
-      cgh.parallel_for<class set_ulisttot>(nd_range<1>(gws_k2, lws_k2), [=] (nd_item<1> item) {
+    sycl::range<1> gws_k2 ((num_atoms+255)/256*256);
+    sycl::range<1> lws_k2 (256);
+    q.submit([&] (sycl::handler &cgh) {
+      auto ulisttot = d_ulisttot.get_access<sycl::access::mode::write>(cgh);
+      auto idxu_block = d_idxu_block.get_access<sycl::access::mode::read>(cgh);
+      cgh.parallel_for<class set_ulisttot>(sycl::nd_range<1>(gws_k2, lws_k2), [=] (sycl::nd_item<1> item) {
         int natom = item.get_global_id(0);
-        if (natom < num_atoms) 
+        if (natom < num_atoms)
           for (int j = 0; j <= twojmax; j++) {
             int jju = idxu_block[j];
             for (int ma = 0; ma <= j; ma++) {
@@ -481,20 +480,20 @@ int main(int argc, char* argv[])
       });
     });
 
-    range<2> gws_k3 ((num_nbor+15)/16*16, (num_atoms+15)/16*16);
-    range<2> lws_k3 (16, 16);
+    sycl::range<2> gws_k3 ((num_nbor+15)/16*16, (num_atoms+15)/16*16);
+    sycl::range<2> lws_k3 (16, 16);
 
-    q.submit([&] (handler &cgh) {
-      auto wj = d_wj.get_access<sycl_read>(cgh);
-      auto rij = d_rij.get_access<sycl_read>(cgh);
-      auto rcutij = d_rcutij.get_access<sycl_read>(cgh);
-      auto ulist_parity = d_ulist_parity.get_access<sycl_read>(cgh);
-      auto idxu_block = d_idxu_block.get_access<sycl_read>(cgh);
-      auto rootpqarray = d_rootpqarray.get_access<sycl_read>(cgh);
-      auto ulist = d_ulist.get_access<sycl_read_write>(cgh);
-      auto ulisttot = d_ulisttot.get_access<sycl_read_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto wj = d_wj.get_access<sycl::access::mode::read>(cgh);
+      auto rij = d_rij.get_access<sycl::access::mode::read>(cgh);
+      auto rcutij = d_rcutij.get_access<sycl::access::mode::read>(cgh);
+      auto ulist_parity = d_ulist_parity.get_access<sycl::access::mode::read>(cgh);
+      auto idxu_block = d_idxu_block.get_access<sycl::access::mode::read>(cgh);
+      auto rootpqarray = d_rootpqarray.get_access<sycl::access::mode::read>(cgh);
+      auto ulist = d_ulist.get_access<sycl::access::mode::read_write>(cgh);
+      auto ulisttot = d_ulisttot.get_access<sycl::access::mode::read_write>(cgh);
 
-      cgh.parallel_for<class update_ulisttot>(nd_range<2>(gws_k3, lws_k3), [=] (nd_item<2> item) {
+      cgh.parallel_for<class update_ulisttot>(sycl::nd_range<2>(gws_k3, lws_k3), [=] (sycl::nd_item<2> item) {
 	int nbor = item.get_global_id(0);
 	int natom = item.get_global_id(1);
         if (natom < num_atoms && nbor < num_nbor) {
@@ -502,17 +501,17 @@ int main(int argc, char* argv[])
           double y = rij[ULIST_INDEX(natom, nbor, 1)];
           double z = rij[ULIST_INDEX(natom, nbor, 2)];
           double rsq = x * x + y * y + z * z;
-          double r = cl::sycl::sqrt(rsq);
+          double r = sycl::sqrt(rsq);
 
           double theta0 = (r - rmin0) * rfac0 * MY_PI / (rcutij[INDEX_2D(natom, nbor)] - rmin0);
-          double z0 = r / cl::sycl::tan(theta0);
+          double z0 = r / sycl::tan(theta0);
 
           double rootpq;
           int jju, jjup;
 
           // compute Cayley-Klein parameters for unit quaternion
 
-          double r0inv = 1.0 / cl::sycl::sqrt(r * r + z0 * z0);
+          double r0inv = 1.0 / sycl::sqrt(r * r + z0 * z0);
           double a_r = r0inv * z0;
           double a_i = -r0inv * z;
           double b_r = r0inv * y;
@@ -644,30 +643,30 @@ int main(int argc, char* argv[])
     //compute_yi(beta);
 
     // Initialize ylist elements to zeros
-    range<1> gws_k4 ((num_atoms*idxdu_max+255)/256*256);
-    range<1> lws_k4 (256);
-    q.submit([&] (handler &cgh) {
-      auto acc = d_ylist.get_access<sycl_write>(cgh);
-      cgh.parallel_for<class reset_ylist>(nd_range<1>(gws_k4, lws_k4), [=] (nd_item<1> item) {
+    sycl::range<1> gws_k4 ((num_atoms*idxdu_max+255)/256*256);
+    sycl::range<1> lws_k4 (256);
+    q.submit([&] (sycl::handler &cgh) {
+      auto acc = d_ylist.get_access<sycl::access::mode::write>(cgh);
+      cgh.parallel_for<class reset_ylist>(sycl::nd_range<1>(gws_k4, lws_k4), [=] (sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
-        if (i < num_atoms*idxdu_max) acc[i] = {0.0, 0.0}; 
+        if (i < num_atoms*idxdu_max) acc[i] = {0.0, 0.0};
       });
     });
 
-    range<2> gws_k5 ((idxz_max+15)/16*16, (num_atoms+15)/16*16);
-    range<2> lws_k5 (16, 16);
+    sycl::range<2> gws_k5 ((idxz_max+15)/16*16, (num_atoms+15)/16*16);
+    sycl::range<2> lws_k5 (16, 16);
 
-    q.submit([&] (handler &cgh) {
-      auto idxz = d_idxz.get_access<sycl_read>(cgh);
-      auto idxzbeta = d_idxzbeta.get_access<sycl_read>(cgh);
-      auto idxcg_block = d_idxcg_block.get_access<sycl_read>(cgh);
-      auto cglist = d_cglist.get_access<sycl_read>(cgh);
-      auto idxu_block = d_idxu_block.get_access<sycl_read>(cgh);
-      auto idxdu_block = d_idxdu_block.get_access<sycl_read>(cgh);
-      auto ulisttot = d_ulisttot.get_access<sycl_read>(cgh);
-      auto ylist = d_ylist.get_access<sycl_read_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto idxz = d_idxz.get_access<sycl::access::mode::read>(cgh);
+      auto idxzbeta = d_idxzbeta.get_access<sycl::access::mode::read>(cgh);
+      auto idxcg_block = d_idxcg_block.get_access<sycl::access::mode::read>(cgh);
+      auto cglist = d_cglist.get_access<sycl::access::mode::read>(cgh);
+      auto idxu_block = d_idxu_block.get_access<sycl::access::mode::read>(cgh);
+      auto idxdu_block = d_idxdu_block.get_access<sycl::access::mode::read>(cgh);
+      auto ulisttot = d_ulisttot.get_access<sycl::access::mode::read>(cgh);
+      auto ylist = d_ylist.get_access<sycl::access::mode::read_write>(cgh);
 
-      cgh.parallel_for<class compute_yi>(nd_range<2>(gws_k5, lws_k5), [=] (nd_item<2> item) {
+      cgh.parallel_for<class compute_yi>(sycl::nd_range<2>(gws_k5, lws_k5), [=] (sycl::nd_item<2> item) {
         int jjz = item.get_global_id(0);
         int natom = item.get_global_id(1);
         if (jjz < idxz_max && natom < num_atoms) {
@@ -752,18 +751,18 @@ int main(int argc, char* argv[])
     // compute_duidrj
     start = system_clock::now();
 
-    range<2> gws_k6 ((num_nbor+15)/16*16, (num_atoms+15)/16*16);
-    range<2> lws_k6 (16, 16);
+    sycl::range<2> gws_k6 ((num_nbor+15)/16*16, (num_atoms+15)/16*16);
+    sycl::range<2> lws_k6 (16, 16);
 
-    q.submit([&] (handler &cgh) {
-      auto wj = d_wj.get_access<sycl_read>(cgh);
-      auto rij = d_rij.get_access<sycl_read>(cgh);
-      auto rcutij = d_rcutij.get_access<sycl_read>(cgh);
-      auto rootpqarray = d_rootpqarray.get_access<sycl_read>(cgh);
-      auto ulist = d_ulist.get_access<sycl_read>(cgh);
-      auto dulist = d_dulist.get_access<sycl_read_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto wj = d_wj.get_access<sycl::access::mode::read>(cgh);
+      auto rij = d_rij.get_access<sycl::access::mode::read>(cgh);
+      auto rcutij = d_rcutij.get_access<sycl::access::mode::read>(cgh);
+      auto rootpqarray = d_rootpqarray.get_access<sycl::access::mode::read>(cgh);
+      auto ulist = d_ulist.get_access<sycl::access::mode::read>(cgh);
+      auto dulist = d_dulist.get_access<sycl::access::mode::read_write>(cgh);
 
-      cgh.parallel_for<class compute_duidrj>(nd_range<2>(gws_k6, lws_k6), [=] (nd_item<2> item) {
+      cgh.parallel_for<class compute_duidrj>(sycl::nd_range<2>(gws_k6, lws_k6), [=] (sycl::nd_item<2> item) {
 	int nbor = item.get_global_id(0);
 	int natom = item.get_global_id(1);
         if (natom < num_atoms && nbor < num_nbor) {
@@ -774,19 +773,19 @@ int main(int argc, char* argv[])
           double y = rij[ULIST_INDEX(natom, nbor, 1)];
           double z = rij[ULIST_INDEX(natom, nbor, 2)];
           double rsq = x * x + y * y + z * z;
-          double r = cl::sycl::sqrt(rsq);
+          double r = sycl::sqrt(rsq);
           double rscale0 = rfac0 * MY_PI / (rcut - rmin0);
           double theta0 = (r - rmin0) * rscale0;
-          double cs = cl::sycl::cos(theta0);
-          double sn = cl::sycl::sin(theta0);
+          double cs = sycl::cos(theta0);
+          double sn = sycl::sin(theta0);
           double z0 = r * cs / sn;
           double dz0dr = z0 / r - (r * rscale0) * (rsq + z0 * z0) / rsq;
 
-          compute_duarray(natom, nbor, num_atoms, num_nbor, twojmax, 
+          compute_duarray(natom, nbor, num_atoms, num_nbor, twojmax,
                           idxdu_max, jdimpq, switch_flag,
                           x, y, z, z0, r, dz0dr, wj_in, rcut,
-                          rootpqarray.get_pointer(), 
-                          ulist.get_pointer(), 
+                          rootpqarray.get_pointer(),
+                          ulist.get_pointer(),
                           dulist.get_pointer());
          }
       });
@@ -799,16 +798,16 @@ int main(int argc, char* argv[])
 
     start = system_clock::now();
     // compute_deidrj();
-    range<2> gws_k7 ((num_nbor+15)/16*16, (num_atoms+15)/16*16);
-    range<2> lws_k7 (16, 16);
+    sycl::range<2> gws_k7 ((num_nbor+15)/16*16, (num_atoms+15)/16*16);
+    sycl::range<2> lws_k7 (16, 16);
 
-    q.submit([&] (handler &cgh) {
-      auto idxdu_block = d_idxdu_block.get_access<sycl_read>(cgh);
-      auto dulist = d_dulist.get_access<sycl_read>(cgh);
-      auto ylist = d_ylist.get_access<sycl_read>(cgh);
-      auto dedr = d_dedr.get_access<sycl_read_write>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto idxdu_block = d_idxdu_block.get_access<sycl::access::mode::read>(cgh);
+      auto dulist = d_dulist.get_access<sycl::access::mode::read>(cgh);
+      auto ylist = d_ylist.get_access<sycl::access::mode::read>(cgh);
+      auto dedr = d_dedr.get_access<sycl::access::mode::read_write>(cgh);
 
-      cgh.parallel_for<class compute_deidrj>(nd_range<2>(gws_k7, lws_k7), [=] (nd_item<2> item) {
+      cgh.parallel_for<class compute_deidrj>(sycl::nd_range<2>(gws_k7, lws_k7), [=] (sycl::nd_item<2> item) {
 	int nbor = item.get_global_id(0);
 	int natom = item.get_global_id(1);
         if (natom < num_atoms && nbor < num_nbor) {
@@ -872,8 +871,8 @@ int main(int argc, char* argv[])
     elapsed = end - start;
     elapsed_deidrj += elapsed.count();
 
-    q.submit([&] (handler &cgh) {
-      auto acc = d_dedr.get_access<sycl_read>(cgh);
+    q.submit([&] (sycl::handler &cgh) {
+      auto acc = d_dedr.get_access<sycl::access::mode::read>(cgh);
       cgh.copy(acc, dedr);
     });
     q.wait();
@@ -903,7 +902,7 @@ int main(int argc, char* argv[])
   }
   auto stop = myclock::now();
   myduration elapsed = stop - begin;
-  double duration = elapsed.count(); 
+  double duration = elapsed.count();
 
   printf("-----------------------\n");
   printf("Summary of TestSNAP run\n");

--- a/testSNAP-sycl/utils.cpp
+++ b/testSNAP-sycl/utils.cpp
@@ -198,7 +198,7 @@ double compute_sfac(double r, double rcut, const int switch_flag)
       return 0.0;
     else {
       double rcutfac = MY_PI / (rcut - rmin0);
-      return 0.5 * (cl::sycl::cos((r - rmin0) * rcutfac) + 1.0);
+      return 0.5 * (sycl::cos((r - rmin0) * rcutfac) + 1.0);
     }
   }
   return 0.0;
@@ -217,7 +217,7 @@ double compute_dsfac(double r, double rcut, const int switch_flag)
       return 0.0;
     else {
       double rcutfac = MY_PI / (rcut - rmin0);
-      return -0.5 * cl::sycl::sin((r - rmin0) * rcutfac) * rcutfac;
+      return -0.5 * sycl::sin((r - rmin0) * rcutfac) * rcutfac;
     }
   }
   return 0.0;
@@ -255,13 +255,13 @@ void compute_duarray(const int natom,
   double uy = y * rinv;
   double uz = z * rinv;
 
-  r0inv = 1.0 / cl::sycl::sqrt(r * r + z0 * z0);
+  r0inv = 1.0 / sycl::sqrt(r * r + z0 * z0);
   a_r = z0 * r0inv;
   a_i = -z * r0inv;
   b_r = y * r0inv;
   b_i = -x * r0inv;
 
-  dr0invdr = -cl::sycl::pow(r0inv, 3.0) * (r + z0 * dz0dr);
+  dr0invdr = -sycl::pow(r0inv, 3.0) * (r + z0 * dz0dr);
 
   dr0inv[0] = dr0invdr * ux;
   dr0inv[1] = dr0invdr * uy;

--- a/warpsort-sycl/main.cpp
+++ b/warpsort-sycl/main.cpp
@@ -1,8 +1,8 @@
-// 
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 //
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <random>
 #include <unordered_set>
@@ -90,7 +90,7 @@ bool test_sortInRegisters(sycl::queue &q, const int repeat) {
     std::sort(sorted.begin(), sorted.end(), std::greater<float>());
 
     double time = 0.0;
-    
+
     for (int i = 0; i < repeat; ++i) {
       std::shuffle(vals.begin(), vals.end(), std::random_device());
       auto out = facebook::cuda::sort(q, vals, time);
@@ -178,11 +178,10 @@ int main(int argc, char** argv) {
   const int repeat = atoi(argv[1]);
 
 #ifdef USE_GPU
-  sycl::gpu_selector dev_sel;
+  sycl::queue q(sycl::gpu_selector_v, sycl::property::queue::in_order());
 #else
-  sycl::cpu_selector dev_sel;
+  sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());
 #endif
-  sycl::queue q(dev_sel, sycl::property::queue::in_order());
 
   bool ok;
   ok = test_sort(q, repeat);


### PR DESCRIPTION
Fix some compiler errors in the SYCL implementations.
Also, fix many compiler deprecation warnings for newer DPC++ versions.