### PR TITLE
Makefile fixes

### DIFF
--- a/accuracy-sycl/Makefile
+++ b/accuracy-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/adam-sycl/Makefile
+++ b/adam-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/addBiasResidualLayerNorm-sycl/Makefile
+++ b/addBiasResidualLayerNorm-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/atan2-sycl/Makefile
+++ b/atan2-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/atomicCost-sycl/Makefile
+++ b/atomicCost-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/atomicPerf-sycl/Makefile
+++ b/atomicPerf-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/attentionMultiHead-sycl/Makefile
+++ b/attentionMultiHead-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/background-subtract-sycl/Makefile
+++ b/background-subtract-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/bincount-sycl/Makefile
+++ b/bincount-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/bitcracker-sycl/Makefile
+++ b/bitcracker-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/bscan-sycl/Makefile
+++ b/bscan-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/ccsd-trpdrv-cuda/Makefile
+++ b/ccsd-trpdrv-cuda/Makefile
@@ -13,7 +13,7 @@ ARCH      = sm_60
 # Program name & source code list
 #===============================================================================
 
-program = test
+program = main
 
 source = ccsd_tengy.cu  ccsd_trpdrv.cu  main.cu
 

--- a/chacha20-sycl/Makefile
+++ b/chacha20-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/channelShuffle-sycl/Makefile
+++ b/channelShuffle-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/channelSum-sycl/Makefile
+++ b/channelSum-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/clink-cuda/Makefile
+++ b/clink-cuda/Makefile
@@ -53,4 +53,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	./$(program)
+	./$(program) 10

--- a/concat-sycl/Makefile
+++ b/concat-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/conversion-sycl/Makefile
+++ b/conversion-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/cooling-sycl/Makefile
+++ b/cooling-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/cross-sycl/Makefile
+++ b/cross-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/dense-embedding-sycl/Makefile
+++ b/dense-embedding-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/dispatch-sycl/Makefile
+++ b/dispatch-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/distort-sycl/Makefile
+++ b/distort-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/doh-sycl/Makefile
+++ b/doh-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/dwconv-sycl/Makefile
+++ b/dwconv-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/eikonal-sycl/Makefile
+++ b/eikonal-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/flip-sycl/Makefile
+++ b/flip-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/gabor-sycl/Makefile
+++ b/gabor-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/gelu-sycl/Makefile
+++ b/gelu-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/glu-sycl/Makefile
+++ b/glu-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/gru-sycl/Makefile
+++ b/gru-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/hausdorff-sycl/Makefile
+++ b/hausdorff-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/hypterm-sycl/Makefile
+++ b/hypterm-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/interval-sycl/Makefile
+++ b/interval-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/logan-sycl/Makefile
+++ b/logan-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/logprob-sycl/Makefile
+++ b/logprob-sycl/Makefile
@@ -9,7 +9,6 @@ DEBUG     = no
 WAVEFRONT = 32
 SYCL_REDUCE = no   # invoke sycl::reduce_over_group()
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/lrn-sycl/Makefile
+++ b/lrn-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/mallocFree-sycl/Makefile
+++ b/mallocFree-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/mask-sycl/Makefile
+++ b/mask-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/matern-sycl/Makefile
+++ b/matern-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/meanshift-sycl/Makefile
+++ b/meanshift-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/michalewicz-sycl/Makefile
+++ b/michalewicz-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/minmax-sycl/Makefile
+++ b/minmax-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/mrc-sycl/Makefile
+++ b/mrc-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/mtf-sycl/Makefile
+++ b/mtf-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/multinomial-sycl/Makefile
+++ b/multinomial-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/myocyte-sycl/Makefile
+++ b/myocyte-sycl/Makefile
@@ -6,7 +6,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/nlll-sycl/Makefile
+++ b/nlll-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/nonzero-sycl/Makefile
+++ b/nonzero-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/overlap-sycl/Makefile
+++ b/overlap-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/p2p-sycl/Makefile
+++ b/p2p-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/p4-sycl/Makefile
+++ b/p4-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/pad-sycl/Makefile
+++ b/pad-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/page-rank-cuda/Makefile
+++ b/page-rank-cuda/Makefile
@@ -12,7 +12,7 @@ ARCH      = sm_60
 # Program name & source code list
 #===============================================================================
 
-program = page-rank
+program = main
 
 source = main.cu
 

--- a/perlin-sycl/Makefile
+++ b/perlin-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/permutate-sycl/Makefile
+++ b/permutate-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/pitch-sycl/Makefile
+++ b/pitch-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/prefetch-sycl/Makefile
+++ b/prefetch-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/pso-sycl/Makefile
+++ b/pso-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/rainflow-sycl/Makefile
+++ b/rainflow-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/relu-sycl/Makefile
+++ b/relu-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/resize-sycl/Makefile
+++ b/resize-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/ring-sycl/Makefile
+++ b/ring-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/rodrigues-sycl/Makefile
+++ b/rodrigues-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/rowwiseMoments-sycl/Makefile
+++ b/rowwiseMoments-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/rsc-sycl/Makefile
+++ b/rsc-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/rsmt-sycl/Makefile
+++ b/rsmt-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/s8n-sycl/Makefile
+++ b/s8n-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/sc-sycl/Makefile
+++ b/sc-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/scan-sycl/Makefile
+++ b/scan-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/scel-sycl/Makefile
+++ b/scel-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/score-sycl/Makefile
+++ b/score-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/simpleMultiDevice-sycl/Makefile
+++ b/simpleMultiDevice-sycl/Makefile
@@ -8,7 +8,6 @@ OPTIMIZE  = yes
 DEBUG     = no
 MAX_GPU   = 4 
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/simpleSpmv-sycl/Makefile
+++ b/simpleSpmv-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/stsg-sycl/Makefile
+++ b/stsg-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/swish-sycl/Makefile
+++ b/swish-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/tensorAccessor-sycl/Makefile
+++ b/tensorAccessor-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/tqs-sycl/Makefile
+++ b/tqs-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/unfold-sycl/Makefile
+++ b/unfold-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/vol2col-sycl/Makefile
+++ b/vol2col-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/wedford-sycl/Makefile
+++ b/wedford-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/word2vec-sycl/Makefile
+++ b/word2vec-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/zeropoint-sycl/Makefile
+++ b/zeropoint-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/zmddft-sycl/Makefile
+++ b/zmddft-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70

--- a/zoom-sycl/Makefile
+++ b/zoom-sycl/Makefile
@@ -7,7 +7,6 @@ CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
 
-SYCL      = yes
 GPU       = yes
 CUDA      = no
 CUDA_ARCH = sm_70


### PR DESCRIPTION
- Added missing augment for the run configuration of `clink-cuda`
- Renamed binary outputs of `ccsd-trpdrv-cuda` and `page-rank-cuda` to align with convention
- Removed the redundant `SYCL` variable from Makefiles