### PR TITLE
aligned-types-hip and egs-hip : align types broken in ChipStar

### DIFF
--- a/aligned-types-hip/main.cu
+++ b/aligned-types-hip/main.cu
@@ -62,31 +62,31 @@ uint8_misaligned;
 ////////////////////////////////////////////////////////////////////////////////
 // Aligned types
 ////////////////////////////////////////////////////////////////////////////////
-typedef struct __align__(4)
+typedef struct
 {
   unsigned char r, g, b, a;
 }
-uchar4_aligned;
+uchar4_aligned __attribute__((aligned(4)));
 
 typedef unsigned int uint_aligned;
 
-typedef struct __align__(8)
+typedef struct
 {
   unsigned int l, a;
 }
-uint2_aligned;
+uint2_aligned __attribute__((aligned(8)));
 
-typedef struct __align__(16)
+typedef struct
 {
   unsigned int r, g, b;
 }
-uint3_aligned;
+uint3_aligned __attribute__((aligned(16)));
 
-typedef struct __align__(16)
+typedef struct
 {
   unsigned int r, g, b, a;
 }
-uint4_aligned;
+uint4_aligned __attribute__((aligned(16)));
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,11 +98,11 @@ uint4_aligned;
 // "Structure of arrays" storage strategy offers best performance
 // in general case. See section 5.1.2 of the Programming Guide.
 ////////////////////////////////////////////////////////////////////////////////
-typedef struct __align__(16)
+typedef struct
 {
   uint4_aligned c1, c2;
 }
-uint8_aligned;
+uint8_aligned __attribute__((aligned(16)));
 
 
 


### PR DESCRIPTION
This PR fixes compilation issue related to aligned-types

Compile errors:
hipcc  -std=c++14 -Wall -g -O3 -c main.cu -o main.o
main.cu:65:26: error: expected unqualified-id
typedef struct __align__(4)
                         ^
main.cu:65:26: error: expected ')'
main.cu:65:25: note: to match this '('
typedef struct __align__(4)
                        ^
main.cu:69:1: error: a type specifier is required for all declarations
uchar4_aligned;
^
main.cu:73:26: error: expected unqualified-id
typedef struct __align__(8)
                         ^
main.cu:73:26: error: expected ')'
main.cu:73:25: note: to match this '('
typedef struct __align__(8)
