### PR TITLE
Put minkowski-hip and minkwski-sycl on the same line

### DIFF
--- a/src/minkowski-hip/main.cu
+++ b/src/minkowski-hip/main.cu
@@ -21,14 +21,14 @@ constexpr int P = m_size / 2;
 
 #include "verify.cpp"
 
-__global__ 
+template <int m, int n, int k>
+__global__
 void minkowski(
   const float *__restrict__ a,
   const float *__restrict__ b,
         float *__restrict__ c,
   const float p,
-  const float one_over_p,
-  const int m, const int n, const int k)
+  const float one_over_p)
 {
   int col = blockIdx.x * blockDim.x + threadIdx.x;
   int row = blockIdx.y * blockDim.y + threadIdx.y;
@@ -101,8 +101,10 @@ int main(int argc, char* argv[]) {
 
     auto start = std::chrono::steady_clock::now();
 
+    auto kernel = minkowski<M, N, P>;
     for (int i = 0; i < repeat; i++)
-      hipLaunchKernelGGL(minkowski, dimGrid, dimBlock, 0, 0, a_device, b_device, c_device, p, one_over_p, M, N, P);
+      hipLaunchKernelGGL(kernel, dimGrid, dimBlock, 0, 0, a_device,
+                         b_device, c_device, p, one_over_p);
 
     hipDeviceSynchronize();
     auto end = std::chrono::steady_clock::now();

--- a/src/minkowski-sycl/main.cpp
+++ b/src/minkowski-sycl/main.cpp
@@ -97,9 +97,9 @@ int main(int argc, char* argv[]) {
             //float sum = sycl::native::powr(sycl::fabs(A[row * N] - B[col]), p);
             #pragma unroll (4)
             for (int i = 0; i < N; i++) {
-              sum += sycl::native::powr(sycl::fabs(a[row * N + i] - b[i * P + col]), p);
+              sum += sycl::pow(sycl::fabs(a[row * N + i] - b[i * P + col]), p);
             }
-            c[row * P + col] = sycl::native::powr(sum, one_over_p);
+            c[row * P + col] = sycl::pow(sum, one_over_p);
           }
         });
       });


### PR DESCRIPTION
The SYCL benchmark gets unfair advantage over HIP one on chipStar (~6x difference) because:

* its kernel uses sycl::native::powr() while HIP uses non-native, non-specialized powf() function.

* its kernel gets "specialized" due to compile-time values of M, N and P variables.

This patch puts the benchmark on the same line by giving the "specialization" benefit for the HIP benchmark and replacing the sycl::native::powr() with sycl::pow().

With this patch the average kernel execution time difference between the benchmarks, when targeting the same device through the same backend (OpenCL in my case), drops to ~1%.