### PR TITLE
ising: fix default iterations to match cuda & hip & sycl

### DIFF
--- a/src/ising-cuda/main.cu
+++ b/src/ising-cuda/main.cu
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
   long long ny = 5120;
   float alpha = 0.1f;
   int nwarmup = 100;
-  int niters = 1000;
+  int niters = 100;
   bool write = false;
   unsigned long long seed = 1234ULL;
 

--- a/src/ising-hip/main.cu
+++ b/src/ising-hip/main.cu
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
   long long ny = 5120;
   float alpha = 0.1f;
   int nwarmup = 100;
-  int niters = 1000;
+  int niters = 100;
   bool write = false;
   unsigned long long seed = 1234ULL;
 


### PR DESCRIPTION
Make default iteration count in HIP and CUDA versions of the ising benchmark to match SYCL one.