### PR TITLE
bspline-vgh-{hip,cuda}: fix miscalculated thread block count

### DIFF
--- a/src/bspline-vgh-cuda/main.cu
+++ b/src/bspline-vgh-cuda/main.cu
@@ -175,7 +175,7 @@ int main(int argc, char ** argv) {
     eval_abc(d2Af,tz,&d2c[0]);              
     cudaMemcpy(d_d2c, d2c, sizeof(float)*4, cudaMemcpyHostToDevice);
 
-    dim3 global_size((spline_num_splines+255)/256*256);
+    dim3 global_size((spline_num_splines+255)/256);
     dim3 local_size(256);
 
     cudaDeviceSynchronize();

--- a/src/bspline-vgh-hip/main.cu
+++ b/src/bspline-vgh-hip/main.cu
@@ -175,7 +175,7 @@ int main(int argc, char ** argv) {
     eval_abc(d2Af,tz,&d2c[0]);              
     hipMemcpy(d_d2c, d2c, sizeof(float)*4, hipMemcpyHostToDevice);
 
-    dim3 global_size((spline_num_splines+255)/256*256);
+    dim3 global_size((spline_num_splines+255)/256);
     dim3 local_size(256);
 
     hipDeviceSynchronize();


### PR DESCRIPTION
Fix bspline-vgh's thread block count in CUDA and HIP versions. Their block count was 256 times more than needed.