### PR TITLE
bitonic-sort: hoist sycl::queue out of timing

### DIFF
--- a/src/bitonic-sort-cuda/main.cu
+++ b/src/bitonic-sort-cuda/main.cu
@@ -207,6 +207,7 @@ int main(int argc, char *argv[]) {
     data_gpu[i] = data_cpu[i] = rand() % 1000;
   }
 
+  cudaFree(0); // Runtime initialization trick below v12.0.
   std::cout << "Bitonic sort (parallel)..\n";
   auto start = std::chrono::steady_clock::now();
 

--- a/src/bitonic-sort-hip/main.cu
+++ b/src/bitonic-sort-hip/main.cu
@@ -207,6 +207,7 @@ int main(int argc, char *argv[]) {
     data_gpu[i] = data_cpu[i] = rand() % 1000;
   }
 
+  hipInit(0);
   std::cout << "Bitonic sort (parallel)..\n";
   auto start = std::chrono::steady_clock::now();
 

--- a/src/bitonic-sort-sycl/main.cpp
+++ b/src/bitonic-sort-sycl/main.cpp
@@ -43,14 +43,7 @@
 
 #define BLOCK_SIZE 256
 
-void ParallelBitonicSort(int input[], int n) {
-
-  // Create queue on implementation-chosen default device.
-#ifdef USE_GPU
-  sycl::queue q(sycl::gpu_selector_v, sycl::property::queue::in_order());
-#else
-  sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());
-#endif
+void ParallelBitonicSort(int input[], int n, sycl::queue &q) {
 
   // n: the exponent used to set the array size. Array size = power(2, n)
   int size = pow(2, n);
@@ -220,10 +213,17 @@ int main(int argc, char *argv[]) {
     data_gpu[i] = data_cpu[i] = rand() % 1000;
   }
 
+  // Create queue on implementation-chosen default device.
+#ifdef USE_GPU
+  sycl::queue q(sycl::gpu_selector_v, sycl::property::queue::in_order());
+#else
+  sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());
+#endif
+
   std::cout << "Bitonic sort (parallel)..\n";
   auto start = std::chrono::steady_clock::now();
 
-  ParallelBitonicSort(data_gpu, n);
+  ParallelBitonicSort(data_gpu, n, q);
 
   auto end = std::chrono::steady_clock::now();
   auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();


### PR DESCRIPTION
bitonic-sort-sycl is a lot slower than the HIP version on chipStar targeting the same device through OpenCL. I guess, it's because sycl::queue creation initiates the SYCL runtime initialization while chipStar runtime is (currently) initialized before dropping to the main() function.

This patch puts CUDA, HIP and SYCL on the same line by initializing the runtime before starting measurements.