### PR TITLE
Fixes for compilation errors in various OpenMP benchmarks

### DIFF
--- a/src/clenergy-omp/Makefile
+++ b/src/clenergy-omp/Makefile
@@ -3,7 +3,7 @@
 #===============================================================================
 
 # Compiler can be set below, or via environment variable
-CC        = icpc
+CC        = icpx
 OPTIMIZE  = yes
 DEBUG     = no
 DEVICE      = gpu

--- a/src/cm-omp/Makefile
+++ b/src/cm-omp/Makefile
@@ -24,7 +24,7 @@ obj = $(source:.cpp=.o)
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Wall 
+CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Wall -I ../cm-cuda/
 
 # Linker Flags
 LDFLAGS = 

--- a/src/distort-omp/main.cpp
+++ b/src/distort-omp/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 
   srand(123);
   for (int i = 0; i < imageSize; i++) {
-    h_src[i] = {rand() % 256, rand() % 256, rand() % 256};
+    h_src[i] = {static_cast<unsigned char>(rand() % 256), static_cast<unsigned char>(rand() % 256), static_cast<unsigned char>(rand() % 256)};
   }
 
   #pragma omp target data map (to: h_src[0:imageSize], h_prop[0:1]) \

--- a/src/gd-omp/Makefile
+++ b/src/gd-omp/Makefile
@@ -24,7 +24,7 @@ obj = main.o utils.o
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall 
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../gd-sycl
 
 # Linker Flags
 LDFLAGS = 

--- a/src/heat-omp/heat.cpp
+++ b/src/heat-omp/heat.cpp
@@ -201,7 +201,7 @@ double solution(const double t, const double x, const double y, const double alp
 
 // Computes the L2-norm of the computed grid and the MMS known solution
 // The known solution is the same as the boundary function.
-double l2norm(const int n, const double * restrict u, const int nsteps, const double dt,
+double l2norm(const int n, const double * u, const int nsteps, const double dt,
               const double alpha, const double dx, const double length) {
 
   // Final (real) time simulated

--- a/src/inversek2j-omp/Makefile
+++ b/src/inversek2j-omp/Makefile
@@ -3,7 +3,7 @@
 #===============================================================================
 
 # Compiler can be set below, or via environment variable
-CC        = icpc
+CC        = icpx
 OPTIMIZE  = yes
 DEBUG     = no
 DEVICE    = gpu
@@ -42,7 +42,7 @@ ifeq ($(OPTIMIZE),yes)
 endif
 
 ifeq ($(DEVICE),gpu)
-  CFLAGS +=-qnextgen -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
+  CFLAGS +=-fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
 else
   CFLAGS +=-qopenmp
 endif

--- a/src/log2-omp/kernel.h
+++ b/src/log2-omp/kernel.h
@@ -79,7 +79,6 @@ void log2_approx (
       }
 
       auto end = std::chrono::high_resolution_clock::now(); 
-      auto end = std::chrono::high_resolution_clock::now(); 
       auto etime = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
       std::cout << "\nIterative approximation with " << precision[i] <<" bits of precision\n";
       std::cout << "Average kernel execution time " << etime * 1e-3 / repeat << " (us)\n";

--- a/src/mandelbrot-omp/main.cpp
+++ b/src/mandelbrot-omp/main.cpp
@@ -36,9 +36,9 @@ void Execute() {
 
   // Report the results
   std::cout << std::setw(20) << "serial time: " << serial_time.count() << "s\n";
-  cout << std::setw(20) << "Average parallel time: "
+  std::cout << std::setw(20) << "Average parallel time: "
                         << (parallel_time / repetitions).count() * 1e3 << " ms\n";
-  cout << std::setw(20) << "Average kernel execution time: "
+  std::cout << std::setw(20) << "Average kernel execution time: "
                         << kernel_time / repetitions * 1e3 << " ms\n";
 
   // Validating

--- a/src/md5hash-omp/Makefile
+++ b/src/md5hash-omp/Makefile
@@ -3,7 +3,7 @@
 #===============================================================================
 
 # Compiler can be set below, or via environment variable
-CC        = icpc
+CC        = icpx
 OPTIMIZE  = yes
 DEBUG     = no
 DEVICE    = gpu
@@ -42,7 +42,7 @@ ifeq ($(OPTIMIZE),yes)
 endif
 
 ifeq ($(DEVICE),gpu)
-  CFLAGS +=-qnextgen -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
+  CFLAGS +=-fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
 else
   CFLAGS +=-qopenmp
 endif

--- a/src/miniFE-omp/src/Makefile
+++ b/src/miniFE-omp/src/Makefile
@@ -12,7 +12,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-CFLAGS = -v -O3 -qnextgen -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__\
+CFLAGS = -v -O3 -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__\
 	-ffp-contract=fast 
 #	-S -emit-llvm
 #\
@@ -39,7 +39,7 @@ LIBS=
 #CXX=g++
 #CC=g++
 
-CXX=icpc
+CXX=icpx
 CC=icc
 LAUNCHER  =
 

--- a/src/miniWeather-omp/Makefile
+++ b/src/miniWeather-omp/Makefile
@@ -48,7 +48,7 @@ endif
 ifeq ($(DEVICE),gpu)
   CFLAGS +=-cxx=icpc -qnextgen -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
 else
-  CFLAGS +=-cxx=icpc 
+  CFLAGS +=--cxx=icpc 
 endif
 #===============================================================================
 # Targets to Build

--- a/src/myocyte-omp/Makefile
+++ b/src/myocyte-omp/Makefile
@@ -33,11 +33,11 @@ endif
 ./myocyte.out:	./main.o \
 	./kernel/kernel_wrapper.o \
 	./util/file/file.o \
-	./util/num/num.o \
+	./util/num/num.o
 	$(CC) $(CFLAGS) ./main.o \
 		./kernel/kernel_wrapper.o \
 		./util/file/file.o \
-		./util/num/num.o
+		./util/num/num.o \
 		$(LDFLAGS) \
 		-o myocyte.out
 

--- a/src/sad-omp/Makefile
+++ b/src/sad-omp/Makefile
@@ -53,7 +53,7 @@ endif
 $(program): $(obj)
 	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
 
-%.o: %.cu ../sad-cuda/bitmap_image.hpp
+%.o: %.cpp ../sad-cuda/bitmap_image.hpp
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:

--- a/src/sw4ck-omp/main.cpp
+++ b/src/sw4ck-omp/main.cpp
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
             alpha_ptr, mua_ptr, lambda_ptr, met_ptr, jac_ptr,
             uacc_ptr, onesided_ptr, cof_ptr, sg_str, nkg, op);
 
-        auto end = std::chrono::steady_clock::now();
+        auto end = std::chrono::high_resolution_clock::now();
         time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
       }
 

--- a/src/swish-omp/main.cpp
+++ b/src/swish-omp/main.cpp
@@ -3,7 +3,6 @@
 #include <math.h>
 #include <chrono>
 #include <random>
-#include <cuda.h>
 #include "reference.h"
 
 #define GPU_THREADS 256

--- a/src/tensorT-omp/main.cpp
+++ b/src/tensorT-omp/main.cpp
@@ -34,7 +34,7 @@ void verify(double *input, double *output) {
   if (!error) printf("PASS\n");
 }
 
-int main(int argv, char **argc) {
+int main(int argc, char **argv) {
   if (argc != 2) {
     printf("Usage: %s <repeat>\n", argv[0]);
     return 1;

--- a/src/zeropoint-omp/Makefile
+++ b/src/zeropoint-omp/Makefile
@@ -53,7 +53,7 @@ $(program): $(obj)
 	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
 
 %.o: %.cpp ../zeropoint-cuda/reference.h
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -I ../zeropoint-cuda -c $< -o $@
 
 clean:
 	rm -rf $(program) $(obj)


### PR DESCRIPTION
icpc related error in `inversek2j-omp`, `clenergy-omp`:
```
icpc: command line error: Use of 'icpc -qnextgen' is not supported, use 'icpx' directly
```

Include paths related errors in `gd-omp`, `sad-omp`, `swish-omp`:
```
icpx  -std=c++17 -Wall  -O3 -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__ -c main.cpp -o main.o
main.cpp:6:10: fatal error: 'utils.h' file not found
```

Logic errors in `log2-omp`:
```
./kernel.h:82:12: error: redefinition of 'end'
      auto end = std::chrono::high_resolution_clock::now();
           ^
```

Logic error in `TensorT-omp`:
```
main.cpp:38:12: error: comparison between pointer and integer ('char **' and 'int')
  if (argc != 2) {
      ~~~~ ^  ~
```

Syntax error in `mandelbrot-omp`:
```
main.cpp:39:3: error: use of undeclared identifier 'cout'; did you mean 'std::cout'?
  cout << std::setw(20) << "Average parallel time: "
```

Syntax errors in `sw4ck-omp`:
```
main.cpp:169:74: error: invalid operands to binary expression ('std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>>' and 'std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>>')
        time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
```

Makefile errors in `myocyte-omp`:
```
make: *** No rule to make target `icpx', needed by `myocyte.out'.  Stop.
```