### PR TITLE
Match kernel code of softmax-hip/cuda to softmax-sycl

### DIFF
--- a/src/softmax-cuda/main.cu
+++ b/src/softmax-cuda/main.cu
@@ -28,7 +28,7 @@ __global__
 void softMax (const int numSlice, const int sliceSize,
               const float* src, float* dest)
 {
-  unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= numSlice) return;
   float max_ = src[i * sliceSize];
   for (int j = 0; j < sliceSize; j++) {

--- a/src/softmax-hip/main.cu
+++ b/src/softmax-hip/main.cu
@@ -28,7 +28,7 @@ __global__
 void softMax (const int numSlice, const int sliceSize,
               const float* src, float* dest)
 {
-  unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= numSlice) return;
   float max_ = src[i * sliceSize];
   for (int j = 1; j < sliceSize; j++) {


### PR DESCRIPTION
Measured that softmax-hip was ~1.56x slower than softmax-sycl targeting the same GPU (Intel ARC A750) until the type of the `i` variable was changed to `int`.