### PR TITLE
tqs-hip/cuda: hipMemcpy -> hipMemcpyAsync to match tqs-sycl

### DIFF
--- a/src/tqs-cuda/main.cu
+++ b/src/tqs-cuda/main.cu
@@ -207,9 +207,9 @@ int main(int argc, char **argv) {
             host_insert_tasks(h_task_queues, h_data_queues, h_task_pool, h_data_pool, &n_written_tasks, p.queue_size,
                               n_consumed_tasks, p.n_gpu_threads);
 
-            cudaMemcpy(d_task_queues, h_task_queues, p.queue_size * sizeof(task_t), cudaMemcpyHostToDevice);
-            cudaMemcpy(d_data_queues, h_data_queues, p.queue_size * p.n_gpu_threads * sizeof(int), cudaMemcpyHostToDevice);
-            cudaMemcpy(d_consumed, h_consumed, sizeof(int), cudaMemcpyHostToDevice);
+            cudaMemcpyAsync(d_task_queues, h_task_queues, p.queue_size * sizeof(task_t), cudaMemcpyHostToDevice);
+            cudaMemcpyAsync(d_data_queues, h_data_queues, p.queue_size * p.n_gpu_threads * sizeof(int), cudaMemcpyHostToDevice);
+            cudaMemcpyAsync(d_consumed, h_consumed, sizeof(int), cudaMemcpyHostToDevice);
 
             // Kernel launch
             call_TaskQueue_gpu(p.n_gpu_blocks, p.n_gpu_threads, d_task_queues, d_data_queues, d_consumed, 

--- a/src/tqs-hip/main.cu
+++ b/src/tqs-hip/main.cu
@@ -207,9 +207,9 @@ int main(int argc, char **argv) {
             host_insert_tasks(h_task_queues, h_data_queues, h_task_pool, h_data_pool, &n_written_tasks, p.queue_size,
                               n_consumed_tasks, p.n_gpu_threads);
 
-            hipMemcpy(d_task_queues, h_task_queues, p.queue_size * sizeof(task_t), hipMemcpyHostToDevice);
-            hipMemcpy(d_data_queues, h_data_queues, p.queue_size * p.n_gpu_threads * sizeof(int), hipMemcpyHostToDevice);
-            hipMemcpy(d_consumed, h_consumed, sizeof(int), hipMemcpyHostToDevice);
+            hipMemcpyAsync(d_task_queues, h_task_queues, p.queue_size * sizeof(task_t), hipMemcpyHostToDevice);
+            hipMemcpyAsync(d_data_queues, h_data_queues, p.queue_size * p.n_gpu_threads * sizeof(int), hipMemcpyHostToDevice);
+            hipMemcpyAsync(d_consumed, h_consumed, sizeof(int), hipMemcpyHostToDevice);
 
             // Kernel launch
             call_TaskQueue_gpu(p.n_gpu_blocks, p.n_gpu_threads, d_task_queues, d_data_queues, d_consumed, 


### PR DESCRIPTION
Replace hipMemcpys to hipMemcpyAsyncs in places where tqs-sycl enqueues asynchronous memcpys. The tqs-hip sped up ~1.19x on an Intel GPU.