### PR TITLE
Compilation fixes for CUDA benchmarks

### DIFF
--- a/src/halo-finder-cuda/Makefile
+++ b/src/halo-finder-cuda/Makefile
@@ -1,4 +1,4 @@
-NVCC_BIN=/auto/software/nvidia/x86_64/cuda-11.0/bin
+NVCC_BIN=nvcc
 
 # the path may be adjusted for each platform
 #MPI_INCLUDE=/usr/lib/x86_64-linux-gnu/openmpi/include
@@ -13,20 +13,20 @@ HACC_PLATFORM=cuda
 HACC_OBJDIR=${HACC_PLATFORM}
 
 HACC_CFLAGS=${OPT} ${OMP} ${NVCC_FLAGS}
-HACC_CC=${NVCC_BIN}/nvcc -x c
+HACC_CC=nvcc -x c
 
 HACC_CXXFLAGS=${OPT} ${OMP} ${NVCC_FLAGS}
-HACC_CXX=${NVCC_BIN}/nvcc
+HACC_CXX=nvcc
 
 HACC_LDFLAGS=-lm -lrt
 
 HACC_NUM_CUDA_DEV="1"
 HACC_MPI_CFLAGS=${OPT} ${OMP} ${NVCC_FLAGS}
-HACC_MPI_CC=${NVCC_BIN}/nvcc -x c
+HACC_MPI_CC=nvcc -x c
 
 HACC_MPI_CXXFLAGS=${OPT} ${OMP} ${NVCC_FLAGS}
-HACC_MPI_CXX=${NVCC_BIN}/nvcc
-HACC_MPI_LD=${NVCC_BIN}/nvcc
+HACC_MPI_CXX=nvcc
+HACC_MPI_LD=nvcc
 
 HACC_MPI_LDFLAGS=-lm -lrt
 

--- a/src/si-cuda/src/main.cu
+++ b/src/si-cuda/src/main.cu
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
         d->offsets = new unsigned int[d->cardinality];
 
         // calculate offsets
-        thrust::exclusive_scan(thrust::host, d->sizes, d->sizes + d->cardinality, d->offsets, 0);
+        thrust::exclusive_scan(d->sizes, d->sizes + d->cardinality, d->offsets, 0);
 
         std::vector<tile> tiles = splitToTiles(d->cardinality, partition);
         std::vector<tile_pair> runs = findTilePairs(d->cardinality, partition);

--- a/src/simpleSpmv-cuda/Makefile
+++ b/src/simpleSpmv-cuda/Makefile
@@ -27,7 +27,7 @@ obj = main.o kernels.o utils.o
 CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Xcompiler -Wall -arch=$(ARCH)
 
 # Linker Flags
-LDFLAGS = 
+LDFLAGS = -lcusparse
 
 # Debug Flags
 ifeq ($(DEBUG),yes)


### PR DESCRIPTION
1. Missing linking with cusparse in simpleSpmv-cuda

```
/usr/bin/ld: kernels.o: in function `spmv_csr(int, int, float const*, unsigned long, float*, float*)':
tmpxft_00212a38_00000000-6_kernels.cudafe1.cpp:(.text+0xa7f): undefined reference to `cusparseCreate'
/usr/bin/ld: tmpxft_00212a38_00000000-6_kernels.cudafe1.cpp:(.text+0xaca): undefined reference to `cusparseCreateCsr'
```

2. Fixing API use in si-cuda

```
si-cuda/src/main.cu(76): error: namespace "thrust" has no member "host"
          thrust::exclusive_scan(thrust::host, d->sizes, d->sizes + d->cardinality, d->offsets, 0);
                                         ^

si-cuda/src/main.cu(76): error: no instance of overloaded function "thrust::exclusive_scan" matches the argument list
            argument types are: (<error-type>, unsigned int *, unsigned int *, unsigned int *, int)
          thrust::exclusive_scan(thrust::host, d->sizes, d->sizes + d->cardinality, d->offsets, 0);
          ^
```