### PR TITLE
Fixed data races.

### DIFF
--- a/src/aidw-cuda/main.cu
+++ b/src/aidw-cuda/main.cu
@@ -143,6 +143,9 @@ void AIDW_Kernel_Tiled(
       dist = (six_s * six_s + siy_s * siy_s);
       t = 1.f / powf(dist, alpha);  sum_dn += t;  sum_up += t * sdz[e];
     }
+  
+  __syncthreads();
+
   }
   iz[tid] = sum_up / sum_dn;
 }

--- a/src/mixbench-cuda/main.cu
+++ b/src/mixbench-cuda/main.cu
@@ -35,6 +35,8 @@ __global__ void benchmark_func(float *g_data, const int blockdim,
         tmps[j] = tmps[j]*tmps[j]+seed;
     }
 
+    __syncthreads();
+
     // Multiply add reduction
     float sum = 0.f;
     #pragma unroll
@@ -44,6 +46,8 @@ __global__ void benchmark_func(float *g_data, const int blockdim,
     #pragma unroll
     for(int j=0; j<granularity; j++)
       g_data[idx+k*big_stride] = sum;
+
+    __syncthreads();
   }
 }
 

--- a/src/word2vec-cuda/cbow.cu
+++ b/src/word2vec-cuda/cbow.cu
@@ -167,6 +167,7 @@ void device_cbow(
           }
       }
     }// End for sentence_idx
+    __syncthreads();
 
     // Update d_random
     if (idInWarp == 0 ) d_random[sentence_position] = next_random;


### PR DESCRIPTION
Hello @zjin-lcf,

@cogumbreiro and I have been working on this repository trying to find the data races using the tool [faial-drf](https://gitlab.com/umb-svl/faial/). This commit fixes the data races in the following programs: 
- aidw-cuda
- mixbench-cuda
- word2vec-cuda

If you'd like me to create a new PR for each of these programs please let me know.

Thanks!