### PR TITLE
sycl::fabs deprecated in SYCL 2020

### DIFF
--- a/src/aop-sycl/main.cpp
+++ b/src/aop-sycl/main.cpp
@@ -155,7 +155,7 @@ static inline void assemble_R(int m, sycl::double4 &sums, double *smem_svds)
   x0 = x1-c1;
   x0_sq = x0*x0;
   sigma = sum2 - 2.0*c1*sum1 + (m_as_dbl-2.0)*c1*c1;
-  if( sycl::abs(sigma) < 1.0e-16 )
+  if( sycl::fabs(sigma) < 1.0e-16 )
     beta = 0.0;
   else
   {
@@ -193,7 +193,7 @@ static inline void assemble_R(int m, sycl::double4 &sums, double *smem_svds)
   
   x0 = x2_sq-c4*x2+c5;
   sigma = sum4 - 2.0*c4*sum3 + (c4*c4 + 2.0*c5)*sum2 - 2.0*c4*c5*sum1 + (m_as_dbl-3.0)*c5*c5;
-  if( sycl::abs(sigma) < 1.0e-12 )
+  if( sycl::fabs(sigma) < 1.0e-12 )
     beta = 0.0;
   else
   {
@@ -404,9 +404,9 @@ static inline void svd_3x3(int m, sycl::double4 &sums, double *smem_svds)
   
   // Invert the diagonal terms and compute V*S^-1.
   
-  double inv_S0 = sycl::abs(A00) < 1.0e-12 ? 0.0 : 1.0 / A00;
-  double inv_S1 = sycl::abs(A11) < 1.0e-12 ? 0.0 : 1.0 / A11;
-  double inv_S2 = sycl::abs(A22) < 1.0e-12 ? 0.0 : 1.0 / A22;
+  double inv_S0 = sycl::fabs(A00) < 1.0e-12 ? 0.0 : 1.0 / A00;
+  double inv_S1 = sycl::fabs(A11) < 1.0e-12 ? 0.0 : 1.0 / A11;
+  double inv_S2 = sycl::fabs(A22) < 1.0e-12 ? 0.0 : 1.0 / A22;
 
   // printf("SVD: timestep=%3d %12.8lf %12.8lf %12.8lf\n", blockIdx.x, sqrt(A00), sqrt(A11), sqrt(A22));
   

--- a/src/degrid-sycl/main.cpp
+++ b/src/degrid-sycl/main.cpp
@@ -10,7 +10,7 @@ void init_gcf(PRECISION2 *gcf, size_t size) {
     for (size_t sub_y=0; sub_y<GCF_GRID; sub_y++ )
       for(size_t x=0; x<size; x++)
         for(size_t y=0; y<size; y++) {
-          PRECISION tmp = sin(6.28*x/size/GCF_GRID)*exp(-(1.0*x*x+1.0*y*y*sub_y)/size/size/2);
+          PRECISION tmp = sycl::sin(6.28*x/size/GCF_GRID)*sycl::exp(-(1.0*x*x+1.0*y*y*sub_y)/size/size/2);
           gcf[size*size*(sub_x+sub_y*GCF_GRID)+x+y*size].x() = tmp*sin(1.0*x*sub_x/(y+1));
           gcf[size*size*(sub_x+sub_y*GCF_GRID)+x+y*size].y() = tmp*cos(1.0*x*sub_x/(y+1));
         }
@@ -117,8 +117,8 @@ int main(void) {
 
   bool ok = true;
   for (size_t n = 0; n < NPOINTS; n++) {
-    if (fabs(out[n].x()-out_cpu[n].x()) > EPS ||
-        fabs(out[n].y()-out_cpu[n].y()) > EPS ) {
+    if (sycl::fabs(out[n].x()-out_cpu[n].x()) > EPS ||
+        sycl::fabs(out[n].y()-out_cpu[n].y()) > EPS ) {
       ok = false;
       std::cout << n << ": F(" << in[n].x() << ", " << in[n].y() << ") = " 
         << out[n].x() << ", " << out[n].y() 

--- a/src/zeropoint-sycl/main.cpp
+++ b/src/zeropoint-sycl/main.cpp
@@ -27,7 +27,7 @@ void zero_point (
       int symmetric_qmin = -((qmax - qmin) / 2 + 1);
       int symmetric_qmax = (qmax - qmin) / 2;
       double max_scale = sycl::fmax(
-          sycl::fabs(min_val / symmetric_qmin), sycl::fabs(max_val / symmetric_qmax));
+          sycl::fabs(min_val / static_cast<double>(symmetric_qmin)), sycl::fabs(max_val / static_cast<double>(symmetric_qmin)));
       min_val = max_scale * symmetric_qmin;
       max_val = max_scale * symmetric_qmax;
     }
@@ -47,8 +47,8 @@ void zero_point (
 
     double zero_point_from_min = qmin - min_val / static_cast<double>(scale[i]);
     double zero_point_from_max = qmax - max_val / static_cast<double>(scale[i]);
-    double zero_point_from_min_error = sycl::abs(qmin) + sycl::abs(min_val / static_cast<double>(scale[i]));
-    double zero_point_from_max_error = sycl::abs(qmax) + sycl::abs(max_val / static_cast<double>(scale[i]));
+    double zero_point_from_min_error = sycl::abs(qmin) + sycl::fabs(min_val / static_cast<double>(scale[i]));
+    double zero_point_from_max_error = sycl::abs(qmax) + sycl::fabs(max_val / static_cast<double>(scale[i]));
     double initial_zero_point = zero_point_from_min_error < zero_point_from_max_error
                                 ? zero_point_from_min
                                 : zero_point_from_max;


### PR DESCRIPTION
 `sycl::abs( double )` is invalid with the SYCL 2020 specification (CF https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#api:fabs ). 
 
 In the current SYCL specification, `sycl::abs()` only support integers.
 To match it, this PR replaces calls to`sycl::abs()` by `sycl::fabs()` when the parameter is a float or double. 