### PR TITLE
Missing q.wait triggers segfaults

### DIFF
--- a/src/hmm-sycl/ViterbiGPU.cpp
+++ b/src/hmm-sycl/ViterbiGPU.cpp
@@ -93,6 +93,7 @@ int ViterbiGPU(float &viterbiProb,
 
   q.memcpy(maxProbNew, d_maxProbNew, sizeof(float)*nState);
   q.memcpy(path, d_path, sizeof(int)*(nObs-1)*nState);
+  q.wait();
 
   // find the final most probable state
   float maxProb = 0.0;

--- a/src/hybridsort-sycl/mergesort.c
+++ b/src/hybridsort-sycl/mergesort.c
@@ -224,8 +224,8 @@ sycl::float4* runMergeSort(sycl::queue &q, int listsize, int divisions,
       cgh.copy(orig_acc, d_origList);
       });
 
-  free(startaddr);
   q.wait();
+  free(startaddr);
 
   return d_origList;
 }


### PR DESCRIPTION
In the hmm-sycl  benchmark, this snippet of code is wrong : 
```
  q.memcpy(maxProbNew, d_maxProbNew, sizeof(float)*nState);
  q.memcpy(path, d_path, sizeof(int)*(nObs-1)*nState);

  // find the final most probable state
  float maxProb = 0.0;
  int maxState = -1;
  for (int i = 0; i < nState; i++)
  {
    if (maxProbNew[i] > maxProb)
    {
[...]
	

```

`maxProbNew` is accessed without ensuring that the copy from `d_maxProbNew` to  `maxProbNew` has been completed. 

This cause the benchmark to segfault on both DPC++ and AdaptiveCpp when selected backend is cpu. ( I wasn't able to test it on GPUs )
Fixing the bug is relatively simple, and requires only to add  `q.wait()` after the two `memcopy`.

In merge sort from hybridsort-sycl benchmark, the same situation occurs here
```
sycl::buffer<int, 1> d_constStartAddr (startaddr, (divisions+1), props);
[...]
q.submit([&](sycl::handler& cgh) {
	[...]
	auto constStartAddr_acc = d_constStartAddr.get_access<sycl_read>(cgh);
	cgh.parallel_for<class mergepack>(
          sycl::nd_range<2>([...]) {
	          [...]
	              orig_acc[constStartAddr_acc[division]*4 + nullElems_acc[division] + idx];
          });
      });
[...]

free(startaddr);
q.wait();
```

`startaddr` is freed while its associated buffer `constStartAddr_acc` might still be used in the SYCL kernel.
Fixing the bug requires to place the `q.wait()` before the `free(startaddr)`

This PR fixes this two issues. 