### PR TITLE
Prefer walltime to CPU time when host and device are CPUs

### DIFF
--- a/src/aobench-sycl/ao.cpp
+++ b/src/aobench-sycl/ao.cpp
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <assert.h>
 #include <math.h>
-#include <time.h>
+#include <chrono>
 #include <sycl/sycl.hpp>
 
 #define WIDTH        256
@@ -377,14 +377,12 @@ int main(int argc, char **argv)
   sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());
 #endif
 
-  clock_t start;
-  start = clock();
+  auto start = std::chrono::steady_clock::now();
   for( int i = 0; i < LOOPMAX; ++i ){
     render( q, img, WIDTH, HEIGHT, NSUBSAMPLES, spheres, plane );
   }
-  clock_t end = clock();
-  float delta = ( float )end - ( float )start;
-  float msec = delta * 1000.0 / ( float )CLOCKS_PER_SEC;
+  auto end = std::chrono::steady_clock::now();
+  auto msec = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
   printf( "Total render time (%d iterations): %f sec.\n", LOOPMAX, msec / 1000.0 );
   printf( "Average render time: %f sec.\n", msec / 1000.0 / (float)LOOPMAX );

--- a/src/ccsd-trpdrv-sycl/main.cpp
+++ b/src/ccsd-trpdrv-sycl/main.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <chrono>
 #include <sycl/sycl.hpp>
 
 
@@ -144,12 +145,14 @@ int main(int argc, char* argv[])
     for (int j=1; j<=nocc; j++) {
       for (int i=1; i<=nocc; i++) {
         for (int k=klo; k<=MIN(khi,i); k++) {
-          clock_t t0 = clock();
+          auto t0 = std::chrono::steady_clock::now();
           ccsd_trpdrv(q, f1n, f1t, f2n, f2t, f3n, f3t, f4n, f4t, eorb,
               &ncor, &nocc, &nvir, &emp4, &emp5, &a, &i, &j, &k, &klo,
               Tij, Tkj, Tia, Tka, Xia, Xka, Jia, Jka, Kia, Kka, Jij, Jkj, Kij, Kkj,
               dintc1, dintx1, t1v1, dintc2, dintx2, t1v2);
-          timers[iter] = (double)(clock()-t0) / CLOCKS_PER_SEC;
+          auto t1 = std::chrono::steady_clock::now();
+          auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+          timers[iter] = time * 1e-9f;
 
           iter++;
           if (iter==maxiter) {

--- a/src/cm-sycl/main.cpp
+++ b/src/cm-sycl/main.cpp
@@ -36,7 +36,7 @@ int main (int argc, char *argv[]) {
   }
 
   // Start to measure the processing time
-  clock_t startTime = clock();
+  auto startTime = std::chrono::steady_clock::now();
 
   // Change to the queries sub-directory and get a list of the query files
   if (changeToSubDirectory(basePath, subDirQueries) != 0) {
@@ -132,8 +132,9 @@ int main (int argc, char *argv[]) {
   }
 
   // Output the total processing time
-  clock_t totalTime = clock() - startTime;
-  std::cout << "Time in taken in seconds :"<< (double)totalTime / ((double)CLOCKS_PER_SEC)<< std::endl;
+  auto endTime = std::chrono::steady_clock::now();
+  auto totalTime = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
+  std::cout << "Time in taken in seconds :"<< (double)totalTime * 1e-9f<< std::endl;
 
   // Output a friendly message, unless everything failed
   if (success)

--- a/src/cm-sycl/utils.h
+++ b/src/cm-sycl/utils.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include <algorithm>
 #include <random>
-#include <ctime>
+#include <chrono>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/src/d3q19-bgk-sycl/main.cpp
+++ b/src/d3q19-bgk-sycl/main.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
+#include <chrono>
 #include <math.h>
 #include <sycl/sycl.hpp>
 #include "kernels.h"
@@ -153,8 +153,8 @@ double run_benchmark(sycl::queue &q, BoxCU &domain, lbm_vars h_vars, lbm_vars d_
   int iter = 0;
   int num_bench_iter = 0;
 
-  clock_t start = clock();
-  clock_t end = 0;
+  auto start = std::chrono::steady_clock::now();
+  auto end = std::chrono::steady_clock::now();
 
   printf("Starting %d warmup iterations\n", bench_ini_iter);
   // Main time loop of the simulation.
@@ -163,7 +163,7 @@ double run_benchmark(sycl::queue &q, BoxCU &domain, lbm_vars h_vars, lbm_vars d_
     bool do_output = iter < bench_ini_iter && iter > 0 && (iter % output_frame == 0 || iter == 149);
     if (iter == bench_ini_iter) {
       printf("Starting %d benchmark iterations\n", bench_max_iter - bench_ini_iter);
-      start = clock();
+      start = std::chrono::steady_clock::now();
     }
     if (iter >= bench_ini_iter) {
       ++num_bench_iter;
@@ -221,9 +221,9 @@ double run_benchmark(sycl::queue &q, BoxCU &domain, lbm_vars h_vars, lbm_vars d_
       }
     }
   }
-  end = clock();
-  double elapsed = ((double)(end - start)) / CLOCKS_PER_SEC;
-  double mlups = ((double)nl*(double)num_bench_iter / elapsed) / 1.e6;
+  end = std::chrono::steady_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  double mlups = ((double)nl*(double)num_bench_iter / (elapsed * 1e-9f)) / 1.e6;
   return mlups;
 }
 

--- a/src/jacobi-sycl/main.cpp
+++ b/src/jacobi-sycl/main.cpp
@@ -44,7 +44,7 @@ void initialize_data (float* f) {
 
 int main () {
   // Begin wall timing
-  std::clock_t start_time = std::clock();
+  auto start_time = std::chrono::steady_clock::now();
 
   // Reserve space for the scalar field and the "old" copy of the data
   float* f = (float*) aligned_alloc(64, N * N * sizeof(float));
@@ -233,7 +233,9 @@ int main () {
   free(f_old);
 
   // End wall timing
-  double duration = (std::clock() - start_time) / (double) CLOCKS_PER_SEC;
+  auto end_time = std::chrono::steady_clock::now();
+  auto total_time = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
+  double duration = total_time * 1e-9;
   std::cout << "Total elapsed time: " << std::setprecision(4) << duration << " seconds" << std::endl;
 
   return 0;

--- a/src/lsqt-sycl/lsqt.cpp
+++ b/src/lsqt-sycl/lsqt.cpp
@@ -27,6 +27,7 @@
 #include "sigma.h"
 #include "vector.h"
 #include <iostream>
+#include <chrono>
 
 static void print_started_random_vector(int i)
 {
@@ -64,42 +65,46 @@ static void print_finished_ldos()
 
 static void run_dos(Model& model, Hamiltonian& H, Vector& random_state)
 {
-  clock_t time_begin = clock();
+  auto time_begin = std::chrono::steady_clock::now();
   find_dos(model, H, random_state, 0);
-  clock_t time_finish = clock();
-  real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
+  auto time_finish = std::chrono::steady_clock::now();
+  auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+  real time_used = time * 1e-9f;
   std::cout << "- Time used for finding DOS = " << time_used << " s" << std::endl;
 }
 
 static void run_vac0(Model& model, Hamiltonian& H, Vector& random_state)
 {
   if (model.calculate_vac0 == 1) {
-    clock_t time_begin = clock();
+    auto time_begin = std::chrono::steady_clock::now();
     find_vac0(model, H, random_state);
-    clock_t time_finish = clock();
-    real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
-    std::cout << "- Time used for finding VAC0 = " << time_used << " s" << std::endl;
+    auto time_finish = std::chrono::steady_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+    real time_used = time * 1e-9f;
+   std::cout << "- Time used for finding VAC0 = " << time_used << " s" << std::endl;
   }
 }
 
 static void run_vac(Model& model, Hamiltonian& H, Vector& random_state)
 {
   if (model.calculate_vac == 1) {
-    clock_t time_begin = clock();
+    auto time_begin = std::chrono::steady_clock::now();
     find_vac(model, H, random_state);
-    clock_t time_finish = clock();
-    real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
-    std::cout << "- Time used for finding VAC = " << time_used << " s" << std::endl;
+    auto time_finish = std::chrono::steady_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+    real time_used = time * 1e-9f;
+   std::cout << "- Time used for finding VAC = " << time_used << " s" << std::endl;
   }
 }
 
 static void run_msd(Model& model, Hamiltonian& H, Vector& random_state)
 {
   if (model.calculate_msd == 1) {
-    clock_t time_begin = clock();
+    auto time_begin = std::chrono::steady_clock::now();
     find_msd(model, H, random_state);
-    clock_t time_finish = clock();
-    real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
+    auto time_finish = std::chrono::steady_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+    real time_used = time * 1e-9f;
     std::cout << "- Time used for finding MSD = " << time_used << " s" << std::endl;
   }
 }
@@ -107,10 +112,11 @@ static void run_msd(Model& model, Hamiltonian& H, Vector& random_state)
 static void run_spin(Model& model, Hamiltonian& H, Vector& random_state)
 {
   if (model.calculate_spin == 1) {
-    clock_t time_begin = clock();
+    auto time_begin = std::chrono::steady_clock::now();
     find_spin_polarization(model, H, random_state);
-    clock_t time_finish = clock();
-    real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
+    auto time_finish = std::chrono::steady_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+    real time_used = time * 1e-9f;
     std::cout << "- Time used for finding spin polarization = " << time_used << " s" << std::endl;
   }
 }
@@ -119,14 +125,15 @@ static void run_ldos(Model& model, Hamiltonian& H, Vector& random_state)
 {
   if (model.calculate_ldos) {
     print_started_ldos();
-    clock_t time_begin = clock();
+    auto time_begin = std::chrono::steady_clock::now();
     for (int i = 0; i < model.number_of_local_orbitals; ++i) {
       int orbital = model.local_orbitals[i];
       model.initialize_state(random_state, orbital);
       find_dos(model, H, random_state, 1);
     }
-    clock_t time_finish = clock();
-    real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
+    auto time_finish = std::chrono::steady_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+    real time_used = time * 1e-9f;
     std::cout << "- Time used for finding LDOS = " << time_used << " s" << std::endl;
     print_finished_ldos();
   }

--- a/src/lsqt-sycl/main.cpp
+++ b/src/lsqt-sycl/main.cpp
@@ -56,10 +56,11 @@ int main(int argc, char* argv[])
       continue;
     }
     print_start(directory);
-    clock_t time_begin = clock();
+    auto time_begin = std::chrono::steady_clock::now();
     lsqt(directory);
-    clock_t time_finish = clock();
-    real time_used = real(time_finish - time_begin) / CLOCKS_PER_SEC;
+    auto time_finish = std::chrono::steady_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(time_finish - time_begin).count();
+    real time_used = time * 1e-9f;
     print_finish(directory, time_used);
   }
   return 0;

--- a/src/miniWeather-sycl/main.cpp
+++ b/src/miniWeather-sycl/main.cpp
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <mpi.h>
-#include <time.h>
+#include <chrono>
 #include <sycl/sycl.hpp>
 
 const double pi        = 3.14159265358979323846264338327;   //Pi
@@ -965,7 +965,7 @@ int main(int argc, char **argv) {
   ////////////////////////////////////////////////////
   // MAIN TIME STEP LOOP
   ////////////////////////////////////////////////////
-  auto c_start = clock();
+  auto c_start = std::chrono::steady_clock::now();
 
   while (etime < sim_time) {
     //If the time step leads to exceeding the simulation time, shorten it for the last step
@@ -992,9 +992,10 @@ int main(int argc, char **argv) {
     etime = etime + dt;
   }
 
-  auto c_end = clock();
+  auto c_end =  std::chrono::steady_clock::now();
+  auto c_time = std::chrono::duration_cast<std::chrono::nanoseconds>(c_end - c_start).count();
   if (masterproc)
-    printf("Total main time step loop: %lf sec\n", ( (double) (c_end-c_start) ) / CLOCKS_PER_SEC);
+    printf("Total main time step loop: %lf sec\n", c_time * 1e-9f );
 
   //Final reductions for mass, kinetic energy, and total energy
   reductions(mass, te, hs, nx, nz, dx, dz, d_state, d_hy_dens_cell, d_hy_dens_theta_cell, q);

--- a/src/simplemoc-sycl/SimpleMOC-kernel_header.h
+++ b/src/simplemoc-sycl/SimpleMOC-kernel_header.h
@@ -6,7 +6,7 @@
 #include<stdlib.h>
 #include<math.h>
 #include<string.h>
-#include<time.h>
+#include<sys/time.h>
 #include<stdbool.h>
 #include<limits.h>
 #include<assert.h>

--- a/src/simplemoc-sycl/init.cpp
+++ b/src/simplemoc-sycl/init.cpp
@@ -109,10 +109,9 @@ double get_time(void)
   return omp_get_wtime();
 #endif
 
-  time_t time;
-  time = clock();
-
-  return (double) time / (double) CLOCKS_PER_SEC;
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (double) tv.tv_usec * 1e-6f + tv.tv_sec;
 }
 
 Source* copy_sources( Input * I, Source *S ) 

--- a/src/sss-sycl/main.cpp
+++ b/src/sss-sycl/main.cpp
@@ -6,7 +6,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
+#include <chrono>
 
 #define SSS     // Runs the Stochastic Shotgun Search
 #define USE_GPU // If uncommented, runs kernels on GPU
@@ -132,8 +132,7 @@ int main(int argc, char *argv[]) {
   long int k;
   Real score;
   char initID[] = {'1', '2', '3'};
-  clock_t start, now;
-  double cpu_time;
+  double wall_time;
 
   // Initializing gsl random variate generators and integration tools
   const gsl_rng_type *T;
@@ -279,7 +278,7 @@ int main(int argc, char *argv[]) {
          num_cases, num_allModels);
 
   // start the stopwatch
-  start = clock();
+  auto start = std::chrono::steady_clock::now();
   k = 0;
   while (nmodes <= maxNmodes) {
     k++;
@@ -354,7 +353,7 @@ int main(int argc, char *argv[]) {
       modesList->UpdateList(globalBestState);
       nmodes++;
       gsl_rng_set(rnd, seedset[nmodes - 1]);
-      start = clock();
+      start = std::chrono::steady_clock::now();
       k = 0;
       localBestScore = NEG_INF;
       globalBestScore = NEG_INF;
@@ -464,13 +463,14 @@ int main(int argc, char *argv[]) {
     for (l = 0; l < L; l++) {
       score += state->pll[l];
     }
-    now = clock();
-    cpu_time = ((double)(now - start)) / CLOCKS_PER_SEC;
+    auto now = std::chrono::steady_clock::now();
+    wall_time =  std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
+    wall_time = wall_time * 1e-9;
     num_allModels += num_cases;
     printf("k=%ld L=%d score=%.4f localBestScore=%.4f globalBestScore=%.4f "
-           "nmodes=%d cpu_time=%.4f num_cases=%d num_allModels=%ld\n",
+           "nmodes=%d wall_time=%.4f num_cases=%d num_allModels=%ld\n",
            k, state->L, score, localBestScore, globalBestScore, nmodes,
-           cpu_time, num_cases, num_allModels);
+           wall_time, num_cases, num_allModels);
 
     if (score > localBestScore) {
       localBestScore = score;

--- a/src/word2vec-sycl/word2vec.cpp
+++ b/src/word2vec-sycl/word2vec.cpp
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <math.h>
 #include <pthread.h>
-#include <time.h>
+#include <chrono>
 #include "cbow.h"
 
 const int vocab_hash_size = 30000000;  // Maximum 30 * 0.7 = 21M words in the vocabulary
@@ -41,7 +41,7 @@ int iter = 5,  classes = 0;
 real alpha = 0.025, starting_alpha, sample = 1e-3;
 real *syn0;
 int * sen;
-clock_t start;
+auto start = std::chrono::steady_clock::now();
 
 int hs = 0, negative = 5;
 int table_size = 1e8;
@@ -360,7 +360,6 @@ void *TrainModelThread(void *id) {
   long long word_count = 0, last_word_count = 0;
   int    local_iter = iter;
   int sentence_num;
-  clock_t now;
   real * alpha_ptr = (float *) sen + MAX_SENTENCE_NUM * MAX_SENTENCE_LENGTH;
   FILE *fi = fopen(train_file, "rb");
   fseek(fi, file_size / (int)num_threads * (long)id, SEEK_SET);
@@ -372,10 +371,12 @@ void *TrainModelThread(void *id) {
       word_count_actual += word_count - last_word_count;
       last_word_count = word_count;
       if ((debug_mode > 1)) {
-        now=clock();
+        auto now = std::chrono::steady_clock::now();
+        auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
+        time *= 1e-9f;
         printf("%cAlpha: %f  Progress: %.2f%%  Words/thread/sec: %.2fk  ", 13, alpha,
             word_count_actual / (real)(iter * train_words + 1) * 100,
-            word_count_actual / ((real)(now - start + 1) / (real)CLOCKS_PER_SEC * 1000));
+            word_count_actual / ((real) time * 1000));
         fflush(stdout);
       }
       alpha = starting_alpha * (1 - word_count_actual / (real)(iter * train_words + 1));
@@ -456,7 +457,7 @@ void TrainModel() {
 
   initializeGPU(q);
 
-  start = clock();
+  start = std::chrono::steady_clock::now();
 
   // Training on a GPU
   for (a = 0; a < num_threads; a++) pthread_create(&pt[a], NULL, TrainModelThread, (void *)a);


### PR DESCRIPTION

Some SYCL benchmarks use CPU time with `std::clock()` to measure elapsed time. This is problematic when the device used is the CPU : The reported time is therefore the sum of each individual times rather than walltime.

This PR replace calls to `std::clock()` by `std::chrono::steady_clock::now()`.