### PR TITLE
[CUDA] Add missing includes

### DIFF
--- a/src/fft-cuda/main.cu
+++ b/src/fft-cuda/main.cu
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <cstring>
 #include <cuda.h>
 
 #ifdef SINGLE_PRECISION

--- a/src/ising-cuda/main.cu
+++ b/src/ising-cuda/main.cu
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <string>
 #include <cstring>
+#include <cuda.h>
 
 #ifdef CURAND
 #include <curand.h>


### PR DESCRIPTION
This PR adds missing includes to two CUDA benchmarks. Adding them allows the benchmarks to be compiled by AdaptiveCpp PCUDA (https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/pcuda.md)